### PR TITLE
fix: mobile layout — collapsible type selector, responsive board

### DIFF
--- a/src/components/Controls/NumberPad.tsx
+++ b/src/components/Controls/NumberPad.tsx
@@ -24,7 +24,7 @@ export function NumberPad({ onNumberClick, onClear, disabled }: NumberPadProps) 
             onClick={() => onNumberClick(num)}
             disabled={disabled}
             variant="secondary"
-            className="w-14 h-14 text-lg font-bold"
+            className="w-12 h-12 sm:w-14 sm:h-14 text-lg font-bold"
           >
             {num}
           </Button>

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SUDOKU_TYPES } from '../../utils/constants';
 import type { SudokuTypeId } from '../../types/index';
@@ -10,36 +11,108 @@ interface SudokuTypeSelectorProps {
 
 /**
  * Sudoku type selector component
+ * Renders as a dropdown on mobile, full button list on large screens
  */
 export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: SudokuTypeSelectorProps) {
   const { t } = useTranslation();
   const types = Object.values(SUDOKU_TYPES);
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
 
   return (
-    <div className="flex flex-col gap-2">
-      {types.map((type) => (
+    <>
+      {/* Mobile/tablet: collapsible dropdown */}
+      <div className="lg:hidden" ref={dropdownRef}>
         <button
-          key={type.id}
-          onClick={() => onTypeChange(type.id)}
+          onClick={() => setOpen(!open)}
           disabled={disabled}
-          className={`
-            px-4 py-3 rounded-lg font-medium transition-colors text-left
-            ${
-              currentType === type.id
-                ? 'bg-purple-600 text-white'
-                : 'bg-gray-100 text-gray-900 hover:bg-gray-200'
-            }
-            disabled:opacity-50 disabled:cursor-not-allowed
-          `}
+          className="w-full px-4 py-3 rounded-lg font-medium bg-purple-600 text-white text-left flex items-center justify-between disabled:opacity-50"
         >
-          <div className="font-bold text-sm">
-            {t(`sudokuTypes.${type.id}.name`)}
+          <div>
+            <div className="font-bold text-sm">
+              {t(`sudokuTypes.${currentType}.name`)}
+            </div>
+            <div className="text-xs opacity-90 mt-0.5">
+              {t(`sudokuTypes.${currentType}.description`)}
+            </div>
           </div>
-          <div className="text-xs opacity-90 mt-1">
-            {t(`sudokuTypes.${type.id}.description`)}
-          </div>
+          <svg
+            className={`w-5 h-5 ml-2 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
         </button>
-      ))}
-    </div>
+
+        {open && (
+          <div className="mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50 relative">
+            {types.map((type) => (
+              <button
+                key={type.id}
+                onClick={() => {
+                  onTypeChange(type.id);
+                  setOpen(false);
+                }}
+                disabled={disabled}
+                className={`
+                  w-full px-4 py-2.5 text-left transition-colors border-b border-gray-100 last:border-b-0
+                  ${currentType === type.id
+                    ? 'bg-purple-50 text-purple-700'
+                    : 'text-gray-900 hover:bg-gray-50'
+                  }
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                `}
+              >
+                <div className="font-bold text-sm">
+                  {t(`sudokuTypes.${type.id}.name`)}
+                </div>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  {t(`sudokuTypes.${type.id}.description`)}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Desktop: full button list */}
+      <div className="hidden lg:flex flex-col gap-2">
+        {types.map((type) => (
+          <button
+            key={type.id}
+            onClick={() => onTypeChange(type.id)}
+            disabled={disabled}
+            className={`
+              px-4 py-3 rounded-lg font-medium transition-colors text-left
+              ${
+                currentType === type.id
+                  ? 'bg-purple-600 text-white'
+                  : 'bg-gray-100 text-gray-900 hover:bg-gray-200'
+              }
+              disabled:opacity-50 disabled:cursor-not-allowed
+            `}
+          >
+            <div className="font-bold text-sm">
+              {t(`sudokuTypes.${type.id}.name`)}
+            </div>
+            <div className="text-xs opacity-90 mt-1">
+              {t(`sudokuTypes.${type.id}.description`)}
+            </div>
+          </button>
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useRef, useMemo } from 'react';
+import { useEffect, useCallback, useRef, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGameState } from '../../hooks/useGameState';
 import { useTimer } from '../../hooks/useTimer';
@@ -186,63 +186,103 @@ export function GameContainer() {
     return map;
   }, [state.activeHint]);
 
+  // Responsive board scaling: measure container width and scale board to fit
+  const boardContainerRef = useRef<HTMLDivElement>(null);
+  const [boardScale, setBoardScale] = useState(1);
+
+  // Native board width varies by variant
+  const nativeBoardWidth = state.sudokuType === 'LITTLE_KILLER' ? 536
+    : state.sudokuType === 'SANDWICH' ? 506
+    : 466; // 450 grid + 16 padding (p-2 = 8px * 2)
+
+  useEffect(() => {
+    const container = boardContainerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const availableWidth = entry.contentRect.width;
+        const scale = Math.min(1, availableWidth / nativeBoardWidth);
+        setBoardScale(scale);
+      }
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [nativeBoardWidth]);
+
+  const boardElement = (
+    <Board
+      board={state.board}
+      initialBoard={state.initialBoard}
+      selectedCell={state.selectedCell}
+      errors={state.errors}
+      notes={state.notes}
+      sudokuType={state.sudokuType}
+      oddEvenMarkers={state.oddEvenMarkers}
+      kropkiDots={state.kropkiDots}
+      killerCages={state.killerCages}
+      littleKillerClues={state.littleKillerClues as never}
+      greaterThanSigns={state.greaterThanSigns}
+      thermos={state.thermos}
+      sandwichClues={state.sandwichClues}
+      hintHighlights={hintHighlights}
+      onCellClick={handleCellClick}
+    />
+  );
+
   return (
-    <div className="min-h-screen bg-gray-100 py-8 px-4">
+    <div className="min-h-screen bg-gray-100 py-4 px-2 sm:py-8 sm:px-4">
       <div className="max-w-6xl mx-auto">
         {/* Header with title and language switcher */}
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-4xl font-bold text-gray-900">
+        <div className="flex items-center justify-between mb-4 sm:mb-8">
+          <h1 className="text-2xl sm:text-4xl font-bold text-gray-900">
             {t('game.title')}
           </h1>
           <LanguageSwitcher />
         </div>
 
-        <div className="flex flex-col lg:flex-row gap-8 items-start justify-center">
+        <div className="flex flex-col lg:flex-row gap-4 lg:gap-8 items-start justify-center">
           {/* Left side - Board with Type and Difficulty */}
-          <div className="flex flex-col gap-4">
-            {/* Sudoku Type Selector */}
-            <div className="bg-white rounded-lg shadow-md p-4">
-              <h3 className="text-sm font-medium text-gray-600 mb-3">
-                {t('game.type', 'Тип:')}
-              </h3>
-              <SudokuTypeSelector
-                currentType={state.sudokuType}
-                onTypeChange={handleTypeChange}
-                disabled={false}
-              />
+          <div className="flex flex-col gap-3 lg:gap-4 w-full lg:w-auto">
+            {/* Type + Difficulty row on mobile, stacked on desktop */}
+            <div className="flex flex-col sm:flex-row lg:flex-col gap-3 lg:gap-4">
+              {/* Sudoku Type Selector */}
+              <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 flex-1 lg:flex-none">
+                <h3 className="text-sm font-medium text-gray-600 mb-2 lg:mb-3">
+                  {t('game.type', 'Тип:')}
+                </h3>
+                <SudokuTypeSelector
+                  currentType={state.sudokuType}
+                  onTypeChange={handleTypeChange}
+                  disabled={false}
+                />
+              </div>
+
+              {/* Difficulty Selector */}
+              <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 flex-1 lg:flex-none">
+                <h3 className="text-sm font-medium text-gray-600 mb-2 lg:mb-3">
+                  {t('game.difficulty')}
+                </h3>
+                <DifficultySelector
+                  currentDifficulty={state.difficulty}
+                  onDifficultyChange={handleDifficultyChange}
+                  disabled={false}
+                />
+              </div>
             </div>
 
-            {/* Difficulty Selector */}
-            <div className="bg-white rounded-lg shadow-md p-4">
-              <h3 className="text-sm font-medium text-gray-600 mb-3">
-                {t('game.difficulty')}
-              </h3>
-              <DifficultySelector
-                currentDifficulty={state.difficulty}
-                onDifficultyChange={handleDifficultyChange}
-                disabled={false}
-              />
-            </div>
-
-            {/* Board */}
-            <div className="flex flex-col items-center">
-              <Board
-                board={state.board}
-                initialBoard={state.initialBoard}
-                selectedCell={state.selectedCell}
-                errors={state.errors}
-                notes={state.notes}
-                sudokuType={state.sudokuType}
-                oddEvenMarkers={state.oddEvenMarkers}
-                kropkiDots={state.kropkiDots}
-                killerCages={state.killerCages}
-                littleKillerClues={state.littleKillerClues as never}
-                greaterThanSigns={state.greaterThanSigns}
-                thermos={state.thermos}
-                sandwichClues={state.sandwichClues}
-                hintHighlights={hintHighlights}
-                onCellClick={handleCellClick}
-              />
+            {/* Board - responsive scaling */}
+            <div ref={boardContainerRef} className="flex flex-col items-center w-full">
+              <div
+                style={{
+                  transform: `scale(${boardScale})`,
+                  transformOrigin: 'top center',
+                  height: boardScale < 1 ? `${nativeBoardWidth * boardScale}px` : 'auto',
+                }}
+              >
+                {boardElement}
+              </div>
 
               {/* Odd-Even Legend */}
               {state.sudokuType === 'ODD_EVEN' && <OddEvenLegend />}
@@ -250,9 +290,9 @@ export function GameContainer() {
           </div>
 
           {/* Right side - Controls */}
-          <div className="flex flex-col gap-6 w-full lg:w-auto">
-            {/* Timer and Status */}
-            <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="flex flex-col gap-4 lg:gap-6 w-full lg:w-auto">
+            {/* Timer and Game Controls - combined on mobile */}
+            <div className="bg-white rounded-lg shadow-md p-4 sm:p-6">
               <div className="flex items-center justify-between mb-4">
                 <span className="text-sm font-medium text-gray-600">{t('game.time')}</span>
                 <div className="flex items-center gap-3">
@@ -277,7 +317,7 @@ export function GameContainer() {
             </div>
 
             {/* Game Controls */}
-            <div className="bg-white rounded-lg shadow-md p-6">
+            <div className="bg-white rounded-lg shadow-md p-4 sm:p-6">
               <GameControls
                 onNewGame={handleNewGame}
                 onCheck={actions.checkSolution}
@@ -300,20 +340,18 @@ export function GameContainer() {
             />
 
             {/* Number Pad */}
-            <div className="bg-white rounded-lg shadow-md p-6">
+            <div className="bg-white rounded-lg shadow-md p-4 sm:p-6">
               <h3 className="text-sm font-medium text-gray-600 mb-3 text-center">
                 {t('game.numberInput')}
               </h3>
               <div className="flex justify-center">
-                <div className="max-w-[180px]">
-                  <NumberPad
-                    onNumberClick={handleNumberClick}
-                    onClear={handleClear}
-                    disabled={
-                      !state.selectedCell || state.gameStatus !== GAME_STATUS.PLAYING
-                    }
-                  />
-                </div>
+                <NumberPad
+                  onNumberClick={handleNumberClick}
+                  onClear={handleClear}
+                  disabled={
+                    !state.selectedCell || state.gameStatus !== GAME_STATUS.PLAYING
+                  }
+                />
               </div>
               <p className="text-xs text-gray-500 mt-3 text-center">
                 {t('controls.keyboard')}


### PR DESCRIPTION
## Summary
- **Type selector** collapses to a dropdown on mobile/tablet (< lg breakpoint). Tap to expand, scrollable list. Full button list still shows on desktop.
- **Board scales down** on narrow screens via CSS `transform: scale()` + `ResizeObserver`. Works for all variants (standard 450px, Little Killer 536px, Sandwich 506px).
- **Tighter spacing** on mobile: reduced padding, smaller gaps, smaller title text.
- **Number pad** buttons slightly smaller on mobile for better fit.

## Test plan
- [ ] Open on 375px mobile viewport — board should fit without horizontal scroll
- [ ] Type selector shows as dropdown on mobile, full list on desktop (lg+)
- [ ] Tap dropdown to expand, select a type, dropdown closes
- [ ] Try Little Killer and Sandwich variants — clue labels should scale correctly
- [ ] Desktop layout unchanged (side-by-side board + controls)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)