### PR TITLE
feat: add ErrorBoundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import { GameProvider } from './context/GameContext';
 import { GameContainer } from './components/Game/GameContainer';
+import { ErrorBoundary } from './components/UI/ErrorBoundary';
 
 function App() {
   return (
-    <GameProvider>
-      <GameContainer />
-    </GameProvider>
+    <ErrorBoundary>
+      <GameProvider>
+        <GameContainer />
+      </GameProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/UI/ErrorBoundary.stories.tsx
+++ b/src/components/UI/ErrorBoundary.stories.tsx
@@ -1,0 +1,47 @@
+import { ErrorBoundary } from './ErrorBoundary';
+
+export default {
+  title: 'UI/ErrorBoundary',
+  component: ErrorBoundary,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+// Component that throws to trigger the boundary
+function BrokenComponent(): never {
+  throw new Error('Test error for Storybook');
+}
+
+export const ErrorStateEn = {
+  render: () => {
+    localStorage.setItem('language', 'en');
+    return (
+      <ErrorBoundary>
+        <BrokenComponent />
+      </ErrorBoundary>
+    );
+  },
+};
+
+export const ErrorStateRu = {
+  render: () => {
+    localStorage.setItem('language', 'ru');
+    return (
+      <ErrorBoundary>
+        <BrokenComponent />
+      </ErrorBoundary>
+    );
+  },
+};
+
+export const NoError = {
+  render: () => (
+    <ErrorBoundary>
+      <div className="p-8 text-center text-gray-600">
+        App renders normally when there is no error.
+      </div>
+    </ErrorBoundary>
+  ),
+};

--- a/src/components/UI/ErrorBoundary.tsx
+++ b/src/components/UI/ErrorBoundary.tsx
@@ -9,6 +9,19 @@ interface State {
   hasError: boolean;
 }
 
+const messages = {
+  en: {
+    title: 'Something went wrong',
+    description: 'An unexpected error occurred. Please reload the page.',
+    reload: 'Reload',
+  },
+  ru: {
+    title: 'Что-то пошло не так',
+    description: 'Произошла непредвиденная ошибка. Пожалуйста, перезагрузите страницу.',
+    reload: 'Перезагрузить',
+  },
+};
+
 export class ErrorBoundary extends Component<Props, State> {
   state: State = { hasError: false };
 
@@ -22,20 +35,23 @@ export class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      const lang = (typeof localStorage !== 'undefined' && localStorage.getItem('language')) || 'ru';
+      const t = lang === 'ru' ? messages.ru : messages.en;
+
       return (
         <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
           <div className="bg-white rounded-lg shadow-md p-8 max-w-md text-center">
             <h1 className="text-2xl font-bold text-gray-900 mb-4">
-              Something went wrong
+              {t.title}
             </h1>
             <p className="text-gray-600 mb-6">
-              An unexpected error occurred. Please reload the page.
+              {t.description}
             </p>
             <button
               onClick={() => window.location.reload()}
               className="px-6 py-3 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 transition-colors"
             >
-              Reload
+              {t.reload}
             </button>
           </div>
         </div>

--- a/src/components/UI/ErrorBoundary.tsx
+++ b/src/components/UI/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
+          <div className="bg-white rounded-lg shadow-md p-8 max-w-md text-center">
+            <h1 className="text-2xl font-bold text-gray-900 mb-4">
+              Something went wrong
+            </h1>
+            <p className="text-gray-600 mb-6">
+              An unexpected error occurred. Please reload the page.
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="px-6 py-3 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 transition-colors"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `ErrorBoundary` component that catches unhandled React errors
- Shows a friendly "Something went wrong" screen with a reload button instead of a blank page
- Wraps the entire app in `App.tsx`

## Test plan
- [ ] App loads normally
- [ ] If a component throws, user sees reload button instead of white screen

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)