### PR TITLE
fix: remove hardcoded i18n fallbacks

### DIFF
--- a/src/components/Board/Cell.tsx
+++ b/src/components/Board/Cell.tsx
@@ -216,9 +216,9 @@ export const Cell = memo(function Cell({
       {oddEvenMarker && (
         <div className="absolute top-0.5 left-0.5 w-3 h-3">
           {oddEvenMarker === 'odd' ? (
-            <div className="w-full h-full rounded-full bg-blue-400 border border-blue-600" title="Odd" />
+            <div className="w-full h-full rounded-full bg-blue-400 border border-blue-600" />
           ) : (
-            <div className="w-full h-full bg-orange-400 border border-orange-600" title="Even" />
+            <div className="w-full h-full bg-orange-400 border border-orange-600" />
           )}
         </div>
       )}

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -250,7 +250,7 @@ export function GameContainer() {
               {/* Sudoku Type Selector */}
               <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 flex-1 lg:flex-none">
                 <h3 className="text-sm font-medium text-gray-600 mb-2 lg:mb-3">
-                  {t('game.type', 'Тип:')}
+                  {t('game.type')}
                 </h3>
                 <SudokuTypeSelector
                   currentType={state.sudokuType}

--- a/src/components/UI/OddEvenLegend.tsx
+++ b/src/components/UI/OddEvenLegend.tsx
@@ -13,7 +13,7 @@ export function OddEvenLegend() {
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 rounded-full bg-blue-400 border border-blue-600" />
           <span className="text-gray-700 font-medium">
-            {t('oddEven.odd', 'Нечетные')}: 1, 3, 5, 7, 9
+            {t('oddEven.odd')}: 1, 3, 5, 7, 9
           </span>
         </div>
 
@@ -21,7 +21,7 @@ export function OddEvenLegend() {
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 bg-orange-400 border border-orange-600" />
           <span className="text-gray-700 font-medium">
-            {t('oddEven.even', 'Четные')}: 2, 4, 6, 8
+            {t('oddEven.even')}: 2, 4, 6, 8
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove Russian fallback string `'Тип:'` from `GameContainer.tsx`
- Remove Russian fallbacks `'Нечетные'`/`'Четные'` from `OddEvenLegend.tsx`
- Remove hardcoded English `title="Odd"`/`title="Even"` from `Cell.tsx` marker divs

All i18n keys exist in both `en.json` and `ru.json`. The fallbacks were causing language mixing (Russian strings showing up in English mode, English tooltips in Russian mode).

## Test plan
- [ ] Switch to English — no Russian text anywhere
- [ ] Switch to Russian — no English text anywhere
- [ ] Odd-Even variant legend shows correct language

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)