### PR TITLE
feat: add ARIA labels and semantic roles

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -220,6 +220,8 @@ export function Board({
       <div
         className="grid grid-cols-9 grid-rows-9 gap-0 bg-white relative"
         style={{ width: '450px', height: '450px' }}
+        role="grid"
+        aria-label="Sudoku board"
       >
         {cellGrid}
       </div>

--- a/src/components/Board/Cell.tsx
+++ b/src/components/Board/Cell.tsx
@@ -126,7 +126,7 @@ export const Cell = memo(function Cell({
       onClick={() => onClick(row, col)}
       role="button"
       tabIndex={0}
-      aria-label={`Cell row ${row + 1} column ${col + 1}`}
+      aria-label={`R${row + 1}C${col + 1}${value !== EMPTY_CELL ? `: ${value}` : ''}`}
     >
       {/* Thermo: tube segments and bulb/center circle, rendered behind everything */}
       {thermoCell && (

--- a/src/components/Controls/DifficultySelector.tsx
+++ b/src/components/Controls/DifficultySelector.tsx
@@ -16,12 +16,14 @@ export function DifficultySelector({ currentDifficulty, onDifficultyChange, disa
   const difficulties = Object.keys(DIFFICULTY_LEVELS) as DifficultyLevel[];
 
   return (
-    <div className="flex gap-2 flex-wrap">
+    <div className="flex gap-2 flex-wrap" role="radiogroup" aria-label={t('game.difficulty')}>
       {difficulties.map((level) => (
         <button
           key={level}
           onClick={() => onDifficultyChange(level)}
           disabled={disabled}
+          role="radio"
+          aria-checked={currentDifficulty === level}
           className={`px-4 py-2 rounded-lg font-medium transition-colors ${
             currentDifficulty === level
               ? 'bg-blue-600 text-white'

--- a/src/components/Controls/NumberPad.tsx
+++ b/src/components/Controls/NumberPad.tsx
@@ -15,7 +15,7 @@ export function NumberPad({ onNumberClick, onClear, disabled }: NumberPadProps) 
   const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2" role="group" aria-label={t('game.numberInput')}>
       {/* 3x3 grid for numbers */}
       <div className="grid grid-cols-3 gap-2">
         {numbers.map((num) => (
@@ -25,6 +25,7 @@ export function NumberPad({ onNumberClick, onClear, disabled }: NumberPadProps) 
             disabled={disabled}
             variant="secondary"
             className="w-12 h-12 sm:w-14 sm:h-14 text-lg font-bold"
+            aria-label={String(num)}
           >
             {num}
           </Button>

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -38,6 +38,8 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
         <button
           onClick={() => setOpen(!open)}
           disabled={disabled}
+          aria-expanded={open}
+          aria-haspopup="listbox"
           className="w-full px-4 py-3 rounded-lg font-medium bg-purple-600 text-white text-left flex items-center justify-between disabled:opacity-50"
         >
           <div>
@@ -57,7 +59,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
         </button>
 
         {open && (
-          <div className="mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50 relative">
+          <div className="mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50 relative" role="listbox">
             {types.map((type) => (
               <button
                 key={type.id}


### PR DESCRIPTION
## Summary
- **NumberPad**: `role="group"` with translated aria-label, each button gets `aria-label`
- **DifficultySelector**: `role="radiogroup"` with `aria-checked` on active button
- **SudokuTypeSelector**: `aria-expanded`/`aria-haspopup` on dropdown trigger, `role="listbox"` on options
- **Board**: `role="grid"` with `aria-label`
- **Cell**: aria-label now includes value (e.g. `R3C5: 7` vs just position)

## Test plan
- [ ] Tab through the app — focus ring visible on all interactive elements
- [ ] Screen reader announces cell values, difficulty selection, number pad buttons
- [ ] Dropdown announces expanded/collapsed state

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)