### PR TITLE
fix: localStorage versioning and corruption recovery

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useReducer, useCallback, useEffect, ReactNode } from 're
 import { createPuzzle } from '../utils/sudokuGenerator';
 import { findConflicts, isSolved, copyBoard } from '../utils/sudokuValidator';
 import { findHintStep } from '../utils/hintEngine';
-import { GAME_STATUS, DIFFICULTY_LEVELS, STORAGE_KEY, EMPTY_CELL } from '../utils/constants';
+import { GAME_STATUS, DIFFICULTY_LEVELS, STORAGE_KEY, SAVE_VERSION, EMPTY_CELL } from '../utils/constants';
 import type {
   GameState,
   GameContextValue,
@@ -64,6 +64,37 @@ const initialState: GameState = {
   thermos: null,
   sandwichClues: null,
 };
+
+// Validate that a parsed object looks like a saved game state
+function isValidSavedState(data: unknown): data is Record<string, unknown> {
+  if (!data || typeof data !== 'object') return false;
+  const obj = data as Record<string, unknown>;
+
+  // Must have a 9x9 board
+  if (!Array.isArray(obj.board) || obj.board.length !== 9) return false;
+  for (const row of obj.board) {
+    if (!Array.isArray(row) || row.length !== 9) return false;
+  }
+
+  // Must have required string fields
+  if (typeof obj.difficulty !== 'string') return false;
+  if (typeof obj.sudokuType !== 'string') return false;
+  if (typeof obj.gameStatus !== 'string') return false;
+
+  return true;
+}
+
+// Migrate saved state from older versions to current
+function migrateSavedState(data: Record<string, unknown>): Record<string, unknown> {
+  const version = typeof data.version === 'number' ? data.version : 0;
+
+  // Version 0 → 1: add version field (no structural changes needed)
+  if (version < 1) {
+    data.version = 1;
+  }
+
+  return data;
+}
 
 // Reducer
 function gameReducer(state: GameState, action: GameAction): GameState {
@@ -320,6 +351,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     if (state.gameStatus !== GAME_STATUS.IDLE) {
       const stateToSave = {
         ...state,
+        version: SAVE_VERSION,
         errors: Array.from(state.errors),
         notes: Array.from(state.notes.entries()).map(([k, v]) => [k, Array.from(v)]),
         activeHint: null,
@@ -341,9 +373,16 @@ export function GameProvider({ children }: { children: ReactNode }) {
     if (savedState) {
       try {
         const parsed = JSON.parse(savedState);
-        dispatch({ type: Actions.LOAD_STATE, payload: parsed });
+        if (!isValidSavedState(parsed)) {
+          console.warn('Saved game data is corrupted, starting fresh');
+          localStorage.removeItem(STORAGE_KEY);
+          return;
+        }
+        const migrated = migrateSavedState(parsed);
+        dispatch({ type: Actions.LOAD_STATE, payload: migrated });
       } catch (error) {
-        console.error('Failed to load saved game:', error);
+        console.warn('Failed to load saved game, starting fresh:', error);
+        localStorage.removeItem(STORAGE_KEY);
       }
     }
   }, []);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -143,3 +143,4 @@ export const KING_MOVES: GridOffset[] = [
 ];
 
 export const STORAGE_KEY = 'sudoku-game-state';
+export const SAVE_VERSION = 1;


### PR DESCRIPTION
## Summary
- Added `SAVE_VERSION` constant (currently 1) to saved game data
- Added `isValidSavedState()` that checks board shape (9x9), required fields (difficulty, sudokuType, gameStatus)
- Added `migrateSavedState()` scaffold for future version bumps
- Corrupted or unparseable saves are cleared instead of crashing the app

Closes #14

## Test plan
- [x] Existing unit tests pass (109 tests)
- [x] ESLint clean
- [ ] Manual: corrupt localStorage value → app starts fresh instead of crashing
- [ ] Manual: delete `version` field from saved state → migration adds it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)