### PR TITLE
fix: cross-browser compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
     <!-- PWA -->
     <link rel="manifest" href="/manifest.json" />

--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4"
   },
+  "browserslist": [
+    ">0.5%",
+    "last 2 versions",
+    "Firefox ESR",
+    "not dead",
+    "iOS >= 14",
+    "Safari >= 14"
+  ],
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
     "@eslint/js": "^9.39.1",

--- a/src/components/Controls/SudokuTypeSelector.test.tsx
+++ b/src/components/Controls/SudokuTypeSelector.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SudokuTypeSelector } from './SudokuTypeSelector';
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('SudokuTypeSelector', () => {
+  const defaultProps = {
+    currentType: 'CLASSIC' as const,
+    onTypeChange: vi.fn(),
+    disabled: false,
+  };
+
+  it('should close dropdown on touchstart outside', () => {
+    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+
+    // Open the mobile dropdown
+    const button = container.querySelector('.lg\\:hidden button')!;
+    fireEvent.click(button);
+
+    // Dropdown should be open
+    expect(screen.getByRole('listbox')).toBeDefined();
+
+    // Simulate touchstart outside the dropdown
+    fireEvent.touchStart(document.body);
+
+    // Dropdown should close
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('should close dropdown on mousedown outside', () => {
+    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+
+    const button = container.querySelector('.lg\\:hidden button')!;
+    fireEvent.click(button);
+
+    expect(screen.getByRole('listbox')).toBeDefined();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('should call onTypeChange when selecting a type', () => {
+    const onTypeChange = vi.fn();
+    const { container } = render(
+      <SudokuTypeSelector {...defaultProps} onTypeChange={onTypeChange} />
+    );
+
+    // Open dropdown
+    const button = container.querySelector('.lg\\:hidden button')!;
+    fireEvent.click(button);
+
+    // Click a type option (second one, DIAGONAL)
+    const options = screen.getByRole('listbox').querySelectorAll('button');
+    fireEvent.click(options[1]!);
+
+    expect(onTypeChange).toHaveBeenCalledWith('DIAGONAL');
+  });
+});

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -22,13 +22,17 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
   // Close dropdown on outside click
   useEffect(() => {
     if (!open) return;
-    const handleClick = (e: MouseEvent) => {
+    const handleClick = (e: MouseEvent | TouchEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
         setOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('touchstart', handleClick);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('touchstart', handleClick);
+    };
   }, [open]);
 
   return (

--- a/src/hooks/useSound.test.ts
+++ b/src/hooks/useSound.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSound } from './useSound';
+
+describe('useSound localStorage safety', () => {
+  const originalGetItem = Storage.prototype.getItem;
+  const originalSetItem = Storage.prototype.setItem;
+
+  afterEach(() => {
+    Storage.prototype.getItem = originalGetItem;
+    Storage.prototype.setItem = originalSetItem;
+  });
+
+  it('should default to true when localStorage.getItem throws', () => {
+    Storage.prototype.getItem = vi.fn(() => {
+      throw new DOMException('blocked');
+    });
+    const { result } = renderHook(() => useSound());
+    expect(result.current.soundEnabled).toBe(true);
+  });
+
+  it('should not throw when localStorage.setItem throws', () => {
+    Storage.prototype.setItem = vi.fn(() => {
+      throw new DOMException('quota exceeded');
+    });
+    const { result } = renderHook(() => useSound());
+    expect(() => {
+      act(() => result.current.toggleSound());
+    }).not.toThrow();
+  });
+
+  it('should read saved preference from localStorage', () => {
+    beforeEach(() => localStorage.clear());
+    localStorage.setItem('sudoku-sound-enabled', 'false');
+    const { result } = renderHook(() => useSound());
+    expect(result.current.soundEnabled).toBe(false);
+  });
+
+  it('should toggle sound state', () => {
+    const { result } = renderHook(() => useSound());
+    const initial = result.current.soundEnabled;
+    act(() => result.current.toggleSound());
+    expect(result.current.soundEnabled).toBe(!initial);
+  });
+});

--- a/src/hooks/useSound.ts
+++ b/src/hooks/useSound.ts
@@ -14,12 +14,18 @@ export function useSound(): UseSoundReturn {
   const audioCtxRef = useRef<AudioContext | null>(null);
 
   const [soundEnabled, setSoundEnabled] = useState<boolean>(() => {
-    const saved = localStorage.getItem(SOUND_ENABLED_KEY);
-    return saved === null ? true : saved === 'true';
+    try {
+      const saved = localStorage.getItem(SOUND_ENABLED_KEY);
+      return saved === null ? true : saved === 'true';
+    } catch {
+      return true;
+    }
   });
 
   useEffect(() => {
-    localStorage.setItem(SOUND_ENABLED_KEY, String(soundEnabled));
+    try {
+      localStorage.setItem(SOUND_ENABLED_KEY, String(soundEnabled));
+    } catch { /* private browsing or quota exceeded */ }
   }, [soundEnabled]);
 
   const getCtx = useCallback((): AudioContext => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,8 +15,11 @@ export default defineConfig({
     projects: [
       // Unit tests project
       {
+        extends: true,
         test: {
           name: 'unit',
+          environment: 'jsdom',
+          setupFiles: './src/test/setup.ts',
           include: ['src/**/*.test.{ts,tsx}'],
           exclude: ['node_modules/**', 'src/**/*.stories.tsx']
         }


### PR DESCRIPTION
## Summary
- **localStorage safety** (#34): `useSound.ts` now wraps `getItem`/`setItem` in try-catch so private browsing and quota-exceeded don't crash the app
- **iOS touch support** (#35): `SudokuTypeSelector` dropdown now closes on `touchstart` outside, not just `mousedown`
- **PWA meta tags** (#36): Added `apple-mobile-web-app-capable` and `apple-mobile-web-app-status-bar-style` for iOS home screen experience
- **browserslist**: Targeting `>0.5%`, last 2 versions, iOS 14+, Safari 14+ so autoprefixer knows what to target
- **vitest fix**: Unit test project now inherits `jsdom` environment properly

## Test plan
- [x] 4 new tests for localStorage safety in `useSound.test.ts`
- [x] 3 new tests for touch/mouse dismiss in `SudokuTypeSelector.test.tsx`
- [x] All existing tests pass

Closes #34, closes #35, closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)