### PR TITLE
fix: collapse type selector on desktop (#43)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -44,17 +44,17 @@ test.describe('Sudoku Sensei – smoke tests', () => {
   });
 
   test('type selector dropdown opens and closes', async ({ page }) => {
-    const trigger = page.locator('[aria-haspopup="true"]');
+    const trigger = page.locator('[aria-haspopup="listbox"]');
     await expect(trigger).toBeVisible({ timeout: 5000 });
     await trigger.click();
 
-    // Menu should appear
-    const menu = page.locator('[role="menu"]');
-    await expect(menu).toBeVisible();
+    // Listbox should appear
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible();
 
     // Click outside to close
     await page.mouse.click(10, 10);
-    await expect(menu).not.toBeVisible();
+    await expect(listbox).not.toBeVisible();
   });
 
   test('new game button generates a fresh puzzle', async ({ page }) => {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -44,22 +44,17 @@ test.describe('Sudoku Sensei – smoke tests', () => {
   });
 
   test('type selector dropdown opens and closes', async ({ page }) => {
-    // Need mobile viewport for dropdown (desktop uses different component).
-    // beforeEach already navigated, but we need to reload at mobile size.
-    await page.setViewportSize({ width: 375, height: 812 });
-    await page.reload();
-
-    const trigger = page.locator('[aria-haspopup="listbox"]');
+    const trigger = page.locator('[aria-haspopup="true"]');
     await expect(trigger).toBeVisible({ timeout: 5000 });
     await trigger.click();
 
-    // Listbox should appear
-    const listbox = page.locator('[role="listbox"]');
-    await expect(listbox).toBeVisible();
+    // Menu should appear
+    const menu = page.locator('[role="menu"]');
+    await expect(menu).toBeVisible();
 
     // Click outside to close
     await page.mouse.click(10, 10);
-    await expect(listbox).not.toBeVisible();
+    await expect(menu).not.toBeVisible();
   });
 
   test('new game button generates a fresh puzzle', async ({ page }) => {

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -11,7 +11,7 @@ interface SudokuTypeSelectorProps {
 
 /**
  * Sudoku type selector component
- * Renders as a dropdown on mobile, full button list on large screens
+ * Collapsible dropdown on all viewports
  */
 export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: SudokuTypeSelectorProps) {
   const { t } = useTranslation();
@@ -31,14 +31,22 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
+  const triggerId = 'type-selector-trigger';
+  const menuId = 'type-selector-menu';
+
   return (
-    <div ref={dropdownRef} className="relative">
+    <div
+      ref={dropdownRef}
+      className="relative"
+      onKeyDown={(e) => { if (e.key === 'Escape') setOpen(false); }}
+    >
       <button
+        id={triggerId}
         onClick={() => setOpen(!open)}
-        onKeyDown={(e) => { if (e.key === 'Escape') setOpen(false); }}
         disabled={disabled}
         aria-expanded={open}
-        aria-haspopup="listbox"
+        aria-haspopup="true"
+        aria-controls={open ? menuId : undefined}
         className="w-full px-4 py-3 rounded-lg font-medium bg-purple-600 text-white text-left flex items-center justify-between disabled:opacity-50"
       >
         <div>
@@ -58,12 +66,16 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
       </button>
 
       {open && (
-        <div className="absolute mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50" role="listbox">
+        <div
+          id={menuId}
+          className="absolute mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50"
+          role="menu"
+          aria-labelledby={triggerId}
+        >
           {types.map((type) => (
             <button
               key={type.id}
-              role="option"
-              aria-selected={currentType === type.id}
+              role="menuitem"
               onClick={() => {
                 onTypeChange(type.id);
                 setOpen(false);

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SUDOKU_TYPES } from '../../utils/constants';
 import type { SudokuTypeId } from '../../types/index';
@@ -18,6 +18,8 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
   const types = Object.values(SUDOKU_TYPES);
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -31,22 +33,70 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
+  // Focus first option when listbox opens, return focus to trigger on close
+  useEffect(() => {
+    if (open) {
+      const firstOption = listboxRef.current?.querySelector<HTMLButtonElement>('[role="option"]');
+      firstOption?.focus();
+    }
+  }, [open]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  const handleListboxKeyDown = (e: React.KeyboardEvent) => {
+    const options = listboxRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]');
+    if (!options?.length) return;
+
+    const focused = document.activeElement as HTMLButtonElement;
+    const currentIndex = Array.from(options).indexOf(focused);
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        options[Math.min(currentIndex + 1, options.length - 1)]?.focus();
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        options[Math.max(currentIndex - 1, 0)]?.focus();
+        break;
+      case 'Home':
+        e.preventDefault();
+        options[0]?.focus();
+        break;
+      case 'End':
+        e.preventDefault();
+        options[options.length - 1]?.focus();
+        break;
+      case 'Escape':
+        e.preventDefault();
+        close();
+        break;
+      case 'Tab':
+        close();
+        break;
+    }
+  };
+
   const triggerId = 'type-selector-trigger';
-  const menuId = 'type-selector-menu';
+  const listboxId = 'type-selector-listbox';
 
   return (
-    <div
-      ref={dropdownRef}
-      className="relative"
-      onKeyDown={(e) => { if (e.key === 'Escape') setOpen(false); }}
-    >
+    <div ref={dropdownRef} className="relative">
       <button
+        ref={triggerRef}
         id={triggerId}
         onClick={() => setOpen(!open)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') setOpen(false);
+          if (e.key === 'ArrowDown' && !open) { e.preventDefault(); setOpen(true); }
+        }}
         disabled={disabled}
         aria-expanded={open}
-        aria-haspopup="true"
-        aria-controls={open ? menuId : undefined}
+        aria-haspopup="listbox"
+        aria-controls={listboxId}
         className="w-full px-4 py-3 rounded-lg font-medium bg-purple-600 text-white text-left flex items-center justify-between disabled:opacity-50"
       >
         <div>
@@ -67,20 +117,31 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
 
       {open && (
         <div
-          id={menuId}
+          ref={listboxRef}
+          id={listboxId}
           className="absolute mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50"
-          role="menu"
+          role="listbox"
           aria-labelledby={triggerId}
+          onKeyDown={handleListboxKeyDown}
         >
           {types.map((type) => (
             <button
               key={type.id}
-              role="menuitem"
+              role="option"
+              aria-selected={currentType === type.id}
               onClick={() => {
                 onTypeChange(type.id);
-                setOpen(false);
+                close();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onTypeChange(type.id);
+                  close();
+                }
               }}
               disabled={disabled}
+              tabIndex={-1}
               className={`
                 w-full px-4 py-2.5 text-left transition-colors border-b border-gray-100 last:border-b-0
                 ${currentType === type.id

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -35,6 +35,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
     <div ref={dropdownRef} className="relative">
       <button
         onClick={() => setOpen(!open)}
+        onKeyDown={(e) => { if (e.key === 'Escape') setOpen(false); }}
         disabled={disabled}
         aria-expanded={open}
         aria-haspopup="listbox"

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -32,89 +32,59 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
   }, [open]);
 
   return (
-    <>
-      {/* Mobile/tablet: collapsible dropdown */}
-      <div className="lg:hidden" ref={dropdownRef}>
-        <button
-          onClick={() => setOpen(!open)}
-          disabled={disabled}
-          aria-expanded={open}
-          aria-haspopup="listbox"
-          className="w-full px-4 py-3 rounded-lg font-medium bg-purple-600 text-white text-left flex items-center justify-between disabled:opacity-50"
+    <div ref={dropdownRef}>
+      <button
+        onClick={() => setOpen(!open)}
+        disabled={disabled}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className="w-full px-4 py-3 rounded-lg font-medium bg-purple-600 text-white text-left flex items-center justify-between disabled:opacity-50"
+      >
+        <div>
+          <div className="font-bold text-sm">
+            {t(`sudokuTypes.${currentType}.name`)}
+          </div>
+          <div className="text-xs opacity-90 mt-0.5">
+            {t(`sudokuTypes.${currentType}.description`)}
+          </div>
+        </div>
+        <svg
+          className={`w-5 h-5 ml-2 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+          fill="none" viewBox="0 0 24 24" stroke="currentColor"
         >
-          <div>
-            <div className="font-bold text-sm">
-              {t(`sudokuTypes.${currentType}.name`)}
-            </div>
-            <div className="text-xs opacity-90 mt-0.5">
-              {t(`sudokuTypes.${currentType}.description`)}
-            </div>
-          </div>
-          <svg
-            className={`w-5 h-5 ml-2 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
-            fill="none" viewBox="0 0 24 24" stroke="currentColor"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
 
-        {open && (
-          <div className="mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50 relative" role="listbox">
-            {types.map((type) => (
-              <button
-                key={type.id}
-                onClick={() => {
-                  onTypeChange(type.id);
-                  setOpen(false);
-                }}
-                disabled={disabled}
-                className={`
-                  w-full px-4 py-2.5 text-left transition-colors border-b border-gray-100 last:border-b-0
-                  ${currentType === type.id
-                    ? 'bg-purple-50 text-purple-700'
-                    : 'text-gray-900 hover:bg-gray-50'
-                  }
-                  disabled:opacity-50 disabled:cursor-not-allowed
-                `}
-              >
-                <div className="font-bold text-sm">
-                  {t(`sudokuTypes.${type.id}.name`)}
-                </div>
-                <div className="text-xs text-gray-500 mt-0.5">
-                  {t(`sudokuTypes.${type.id}.description`)}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Desktop: full button list */}
-      <div className="hidden lg:flex flex-col gap-2">
-        {types.map((type) => (
-          <button
-            key={type.id}
-            onClick={() => onTypeChange(type.id)}
-            disabled={disabled}
-            className={`
-              px-4 py-3 rounded-lg font-medium transition-colors text-left
-              ${
-                currentType === type.id
-                  ? 'bg-purple-600 text-white'
-                  : 'bg-gray-100 text-gray-900 hover:bg-gray-200'
-              }
-              disabled:opacity-50 disabled:cursor-not-allowed
-            `}
-          >
-            <div className="font-bold text-sm">
-              {t(`sudokuTypes.${type.id}.name`)}
-            </div>
-            <div className="text-xs opacity-90 mt-1">
-              {t(`sudokuTypes.${type.id}.description`)}
-            </div>
-          </button>
-        ))}
-      </div>
-    </>
+      {open && (
+        <div className="mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50 relative" role="listbox">
+          {types.map((type) => (
+            <button
+              key={type.id}
+              onClick={() => {
+                onTypeChange(type.id);
+                setOpen(false);
+              }}
+              disabled={disabled}
+              className={`
+                w-full px-4 py-2.5 text-left transition-colors border-b border-gray-100 last:border-b-0
+                ${currentType === type.id
+                  ? 'bg-purple-50 text-purple-700'
+                  : 'text-gray-900 hover:bg-gray-50'
+                }
+                disabled:opacity-50 disabled:cursor-not-allowed
+              `}
+            >
+              <div className="font-bold text-sm">
+                {t(`sudokuTypes.${type.id}.name`)}
+              </div>
+              <div className="text-xs text-gray-500 mt-0.5">
+                {t(`sudokuTypes.${type.id}.description`)}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -32,7 +32,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
   }, [open]);
 
   return (
-    <div ref={dropdownRef}>
+    <div ref={dropdownRef} className="relative">
       <button
         onClick={() => setOpen(!open)}
         disabled={disabled}
@@ -57,10 +57,12 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
       </button>
 
       {open && (
-        <div className="mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50 relative" role="listbox">
+        <div className="absolute mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50" role="listbox">
           {types.map((type) => (
             <button
               key={type.id}
+              role="option"
+              aria-selected={currentType === type.id}
               onClick={() => {
                 onTypeChange(type.id);
                 setOpen(false);

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -266,11 +266,11 @@ export function GameContainer() {
         <div className="flex flex-col lg:flex-row gap-4 lg:gap-8 items-start justify-center">
           {/* Left side - Board with Type and Difficulty */}
           <div className="flex flex-col gap-3 lg:gap-4 w-full lg:w-auto">
-            {/* Type + Difficulty row on mobile, stacked on desktop */}
-            <div className="flex flex-col sm:flex-row lg:flex-col gap-3 lg:gap-4">
+            {/* Type + Difficulty row */}
+            <div className="flex flex-col sm:flex-row gap-3 lg:gap-4">
               {/* Sudoku Type Selector */}
-              <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 flex-1 lg:flex-none">
-                <h3 className="text-sm font-medium text-gray-600 mb-2 lg:mb-3">
+              <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 flex-1">
+                <h3 className="text-sm font-medium text-gray-600 mb-2">
                   {t('game.type')}
                 </h3>
                 <SudokuTypeSelector
@@ -281,8 +281,8 @@ export function GameContainer() {
               </div>
 
               {/* Difficulty Selector */}
-              <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 flex-1 lg:flex-none">
-                <h3 className="text-sm font-medium text-gray-600 mb-2 lg:mb-3">
+              <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 flex-1">
+                <h3 className="text-sm font-medium text-gray-600 mb-2">
                   {t('game.difficulty')}
                 </h3>
                 <DifficultySelector


### PR DESCRIPTION
## Summary
- Type selector now uses collapsible dropdown on all viewports (was full 13-button vertical list on desktop)
- Grid, controls, and number pad all visible above the fold
- No change to mobile/tablet layout (already used dropdown)

## Before
Grid at y=1272px, page height 1762px on 1280x720. User scrolls 2 screens to see the puzzle.

## After
Grid immediately below type+difficulty selectors. Everything above the fold.

## Test plan
- [x] Unit tests pass (168 tests)
- [x] Lint clean
- [x] Desktop screenshot verified (grid above fold)
- [x] Mobile screenshot verified (no regression)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)