### PR TITLE
fix: scroll indicator on type dropdown + select-cell hint

### DIFF
--- a/src/components/Controls/SudokuTypeSelector.test.tsx
+++ b/src/components/Controls/SudokuTypeSelector.test.tsx
@@ -17,11 +17,11 @@ describe('SudokuTypeSelector', () => {
   };
 
   it('should close dropdown on touchstart outside', () => {
-    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+    render(<SudokuTypeSelector {...defaultProps} />);
 
-    // Open the mobile dropdown
-    const button = container.querySelector('.lg\\:hidden button')!;
-    fireEvent.click(button);
+    // Open dropdown via trigger button
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger);
 
     // Dropdown should be open
     expect(screen.getByRole('listbox')).toBeDefined();
@@ -34,10 +34,10 @@ describe('SudokuTypeSelector', () => {
   });
 
   it('should close dropdown on mousedown outside', () => {
-    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+    render(<SudokuTypeSelector {...defaultProps} />);
 
-    const button = container.querySelector('.lg\\:hidden button')!;
-    fireEvent.click(button);
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger);
 
     expect(screen.getByRole('listbox')).toBeDefined();
 
@@ -48,16 +48,16 @@ describe('SudokuTypeSelector', () => {
 
   it('should call onTypeChange when selecting a type', () => {
     const onTypeChange = vi.fn();
-    const { container } = render(
+    render(
       <SudokuTypeSelector {...defaultProps} onTypeChange={onTypeChange} />
     );
 
     // Open dropdown
-    const button = container.querySelector('.lg\\:hidden button')!;
-    fireEvent.click(button);
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger);
 
     // Click a type option (second one, DIAGONAL)
-    const options = screen.getByRole('listbox').querySelectorAll('button');
+    const options = screen.getAllByRole('option');
     fireEvent.click(options[1]!);
 
     expect(onTypeChange).toHaveBeenCalledWith('DIAGONAL');

--- a/src/components/Controls/SudokuTypeSelector.test.tsx
+++ b/src/components/Controls/SudokuTypeSelector.test.tsx
@@ -62,4 +62,44 @@ describe('SudokuTypeSelector', () => {
 
     expect(onTypeChange).toHaveBeenCalledWith('DIAGONAL');
   });
+
+  it('should show scroll hint gradient when listbox is scrollable', () => {
+    // Mock scrollHeight > clientHeight to simulate scrollable list
+    const originalGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get() { return 500; } });
+    const clientGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get() { return 256; } });
+
+    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger);
+
+    // Gradient overlay should be present
+    const gradient = container.querySelector('[aria-hidden="true"]');
+    expect(gradient).not.toBeNull();
+
+    // Restore
+    if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
+    if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+  });
+
+  it('should hide scroll hint when not scrollable', () => {
+    // Mock scrollHeight === clientHeight
+    const originalGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get() { return 200; } });
+    const clientGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get() { return 200; } });
+
+    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger);
+
+    // Gradient overlay should NOT be present
+    const gradient = container.querySelector('[aria-hidden="true"]');
+    expect(gradient).toBeNull();
+
+    // Restore
+    if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
+    if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+  });
 });

--- a/src/components/Controls/SudokuTypeSelector.test.tsx
+++ b/src/components/Controls/SudokuTypeSelector.test.tsx
@@ -64,42 +64,40 @@ describe('SudokuTypeSelector', () => {
   });
 
   it('should show scroll hint gradient when listbox is scrollable', () => {
-    // Mock scrollHeight > clientHeight to simulate scrollable list
     const originalGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get() { return 500; } });
     const clientGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get() { return 256; } });
 
-    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
-    const trigger = screen.getByRole('button', { expanded: false });
-    fireEvent.click(trigger);
+    try {
+      const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+      const trigger = screen.getByRole('button', { expanded: false });
+      fireEvent.click(trigger);
 
-    // Gradient overlay should be present
-    const gradient = container.querySelector('[aria-hidden="true"]');
-    expect(gradient).not.toBeNull();
-
-    // Restore
-    if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
-    if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+      const gradient = container.querySelector('[data-testid="scroll-gradient"]');
+      expect(gradient).not.toBeNull();
+    } finally {
+      if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
+      if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+    }
   });
 
   it('should hide scroll hint when not scrollable', () => {
-    // Mock scrollHeight === clientHeight
     const originalGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get() { return 200; } });
     const clientGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get() { return 200; } });
 
-    const { container } = render(<SudokuTypeSelector {...defaultProps} />);
-    const trigger = screen.getByRole('button', { expanded: false });
-    fireEvent.click(trigger);
+    try {
+      const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+      const trigger = screen.getByRole('button', { expanded: false });
+      fireEvent.click(trigger);
 
-    // Gradient overlay should NOT be present
-    const gradient = container.querySelector('[aria-hidden="true"]');
-    expect(gradient).toBeNull();
-
-    // Restore
-    if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
-    if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+      const gradient = container.querySelector('[data-testid="scroll-gradient"]');
+      expect(gradient).toBeNull();
+    } finally {
+      if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
+      if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+    }
   });
 });

--- a/src/components/Controls/SudokuTypeSelector.test.tsx
+++ b/src/components/Controls/SudokuTypeSelector.test.tsx
@@ -20,7 +20,7 @@ describe('SudokuTypeSelector', () => {
     render(<SudokuTypeSelector {...defaultProps} />);
 
     // Open dropdown via trigger button
-    const trigger = screen.getByRole('button', { expanded: false });
+    const trigger = screen.getByRole('button', { name: /classic/i });
     fireEvent.click(trigger);
 
     // Dropdown should be open
@@ -36,7 +36,7 @@ describe('SudokuTypeSelector', () => {
   it('should close dropdown on mousedown outside', () => {
     render(<SudokuTypeSelector {...defaultProps} />);
 
-    const trigger = screen.getByRole('button', { expanded: false });
+    const trigger = screen.getByRole('button', { name: /classic/i });
     fireEvent.click(trigger);
 
     expect(screen.getByRole('listbox')).toBeDefined();
@@ -53,7 +53,7 @@ describe('SudokuTypeSelector', () => {
     );
 
     // Open dropdown
-    const trigger = screen.getByRole('button', { expanded: false });
+    const trigger = screen.getByRole('button', { name: /classic/i });
     fireEvent.click(trigger);
 
     // Click a type option (second one, DIAGONAL)
@@ -71,7 +71,7 @@ describe('SudokuTypeSelector', () => {
 
     try {
       const { container } = render(<SudokuTypeSelector {...defaultProps} />);
-      const trigger = screen.getByRole('button', { expanded: false });
+      const trigger = screen.getByRole('button', { name: /classic/i });
       fireEvent.click(trigger);
 
       const gradient = container.querySelector('[data-testid="scroll-gradient"]');
@@ -90,7 +90,7 @@ describe('SudokuTypeSelector', () => {
 
     try {
       const { container } = render(<SudokuTypeSelector {...defaultProps} />);
-      const trigger = screen.getByRole('button', { expanded: false });
+      const trigger = screen.getByRole('button', { name: /classic/i });
       fireEvent.click(trigger);
 
       const gradient = container.querySelector('[data-testid="scroll-gradient"]');

--- a/src/components/Controls/SudokuTypeSelector.test.tsx
+++ b/src/components/Controls/SudokuTypeSelector.test.tsx
@@ -63,41 +63,65 @@ describe('SudokuTypeSelector', () => {
     expect(onTypeChange).toHaveBeenCalledWith('DIAGONAL');
   });
 
-  it('should show scroll hint gradient when listbox is scrollable', () => {
-    const originalGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get() { return 500; } });
-    const clientGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
-    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get() { return 256; } });
+  describe('scroll hint gradient', () => {
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
 
-    try {
-      const { container } = render(<SudokuTypeSelector {...defaultProps} />);
-      const trigger = screen.getByRole('button', { name: /classic/i });
-      fireEvent.click(trigger);
-
-      const gradient = container.querySelector('[data-testid="scroll-gradient"]');
-      expect(gradient).not.toBeNull();
-    } finally {
-      if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
-      if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+    function mockScrollDimensions(scrollH: number, clientH: number) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get() { return scrollH; } });
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get() { return clientH; } });
     }
-  });
 
-  it('should hide scroll hint when not scrollable', () => {
-    const originalGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get() { return 200; } });
-    const clientGetter = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
-    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get() { return 200; } });
-
-    try {
-      const { container } = render(<SudokuTypeSelector {...defaultProps} />);
-      const trigger = screen.getByRole('button', { name: /classic/i });
-      fireEvent.click(trigger);
-
-      const gradient = container.querySelector('[data-testid="scroll-gradient"]');
-      expect(gradient).toBeNull();
-    } finally {
-      if (originalGetter) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalGetter);
-      if (clientGetter) Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientGetter);
+    function restoreScrollDimensions() {
+      if (originalScrollHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+      } else {
+        delete (HTMLElement.prototype as Record<string, unknown>).scrollHeight;
+      }
+      if (originalClientHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+      } else {
+        delete (HTMLElement.prototype as Record<string, unknown>).clientHeight;
+      }
     }
+
+    afterEach(() => {
+      restoreScrollDimensions();
+    });
+
+    it('should show gradient when listbox is scrollable', () => {
+      mockScrollDimensions(500, 256);
+
+      const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: /classic/i }));
+
+      expect(container.querySelector('[data-testid="scroll-gradient"]')).not.toBeNull();
+    });
+
+    it('should hide gradient when not scrollable', () => {
+      mockScrollDimensions(200, 200);
+
+      const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: /classic/i }));
+
+      expect(container.querySelector('[data-testid="scroll-gradient"]')).toBeNull();
+    });
+
+    it('should hide gradient when scrolled to bottom', () => {
+      mockScrollDimensions(500, 256);
+
+      const { container } = render(<SudokuTypeSelector {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: /classic/i }));
+
+      // Gradient should be visible initially
+      expect(container.querySelector('[data-testid="scroll-gradient"]')).not.toBeNull();
+
+      // Simulate scrolling to bottom
+      const listbox = screen.getByRole('listbox');
+      Object.defineProperty(listbox, 'scrollTop', { configurable: true, value: 244 });
+      fireEvent.scroll(listbox);
+
+      expect(container.querySelector('[data-testid="scroll-gradient"]')).toBeNull();
+    });
   });
 });

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -56,6 +56,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
 
   const handleScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
     const el = e.currentTarget;
+    // 8px accounts for sub-pixel rounding across browsers
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
     setShowScrollHint(!atBottom);
   }, []);
@@ -183,7 +184,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
             ))}
           </div>
           {showScrollHint && (
-            <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent rounded-b-lg pointer-events-none" aria-hidden="true" />
+            <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent rounded-b-lg pointer-events-none" aria-hidden="true" data-testid="scroll-gradient" />
           )}
         </div>
       )}

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, type UIEvent } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, type UIEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SUDOKU_TYPES } from '../../utils/constants';
 import type { SudokuTypeId } from '../../types/index';
@@ -38,13 +38,19 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
     };
   }, [open]);
 
-  // Focus first option when listbox opens; check if scrollable
+  // Measure scrollability synchronously before paint to avoid gradient flash
+  useLayoutEffect(() => {
+    if (open) {
+      const el = listboxRef.current;
+      if (el) setShowScrollHint(el.scrollHeight > el.clientHeight);
+    }
+  }, [open]);
+
+  // Focus first option when listbox opens
   useEffect(() => {
     if (open) {
       const firstOption = listboxRef.current?.querySelector<HTMLButtonElement>('[role="option"]');
       firstOption?.focus();
-      const el = listboxRef.current;
-      if (el) setShowScrollHint(el.scrollHeight > el.clientHeight);
     }
   }, [open]);
 

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -22,12 +22,18 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
   const triggerRef = useRef<HTMLButtonElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
 
+  const close = useCallback(() => {
+    setOpen(false);
+    setShowScrollHint(true);
+    triggerRef.current?.focus();
+  }, []);
+
   // Close dropdown on outside click
   useEffect(() => {
     if (!open) return;
     const handleClick = (e: MouseEvent | TouchEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setOpen(false);
+        close();
       }
     };
     document.addEventListener('mousedown', handleClick);
@@ -36,7 +42,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
       document.removeEventListener('mousedown', handleClick);
       document.removeEventListener('touchstart', handleClick);
     };
-  }, [open]);
+  }, [open, close]);
 
   // Measure scrollability synchronously before paint to avoid gradient flash
   useLayoutEffect(() => {
@@ -59,12 +65,6 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
     // 8px accounts for sub-pixel rounding across browsers
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
     setShowScrollHint(!atBottom);
-  }, []);
-
-  const close = useCallback(() => {
-    setOpen(false);
-    setShowScrollHint(true);
-    triggerRef.current?.focus();
   }, []);
 
   const handleListboxKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -17,7 +17,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
   const { t } = useTranslation();
   const types = Object.values(SUDOKU_TYPES);
   const [open, setOpen] = useState(false);
-  const [showScrollHint, setShowScrollHint] = useState(false);
+  const [showScrollHint, setShowScrollHint] = useState(true);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
@@ -48,14 +48,15 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
     }
   }, [open]);
 
-  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
+  const handleScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
     const el = e.currentTarget;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
     setShowScrollHint(!atBottom);
-  };
+  }, []);
 
   const close = useCallback(() => {
     setOpen(false);
+    setShowScrollHint(true);
     triggerRef.current?.focus();
   }, []);
 
@@ -176,7 +177,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
             ))}
           </div>
           {showScrollHint && (
-            <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent rounded-b-lg pointer-events-none" />
+            <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent rounded-b-lg pointer-events-none" aria-hidden="true" />
           )}
         </div>
       )}

--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, type UIEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SUDOKU_TYPES } from '../../utils/constants';
 import type { SudokuTypeId } from '../../types/index';
@@ -17,6 +17,7 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
   const { t } = useTranslation();
   const types = Object.values(SUDOKU_TYPES);
   const [open, setOpen] = useState(false);
+  const [showScrollHint, setShowScrollHint] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
@@ -37,13 +38,21 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
     };
   }, [open]);
 
-  // Focus first option when listbox opens, return focus to trigger on close
+  // Focus first option when listbox opens; check if scrollable
   useEffect(() => {
     if (open) {
       const firstOption = listboxRef.current?.querySelector<HTMLButtonElement>('[role="option"]');
       firstOption?.focus();
+      const el = listboxRef.current;
+      if (el) setShowScrollHint(el.scrollHeight > el.clientHeight);
     }
   }, [open]);
+
+  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+    setShowScrollHint(!atBottom);
+  };
 
   const close = useCallback(() => {
     setOpen(false);
@@ -120,49 +129,55 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
       </button>
 
       {open && (
-        <div
-          ref={listboxRef}
-          id={listboxId}
-          className="absolute mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto z-50"
-          role="listbox"
-          aria-labelledby={triggerId}
-          onKeyDown={handleListboxKeyDown}
-        >
-          {types.map((type) => (
-            <button
-              key={type.id}
-              role="option"
-              aria-selected={currentType === type.id}
-              onClick={() => {
-                onTypeChange(type.id);
-                close();
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
+        <div className="absolute mt-1 w-full z-50">
+          <div
+            ref={listboxRef}
+            id={listboxId}
+            className="w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto"
+            role="listbox"
+            aria-labelledby={triggerId}
+            onKeyDown={handleListboxKeyDown}
+            onScroll={handleScroll}
+          >
+            {types.map((type) => (
+              <button
+                key={type.id}
+                role="option"
+                aria-selected={currentType === type.id}
+                onClick={() => {
                   onTypeChange(type.id);
                   close();
-                }
-              }}
-              disabled={disabled}
-              tabIndex={-1}
-              className={`
-                w-full px-4 py-2.5 text-left transition-colors border-b border-gray-100 last:border-b-0
-                ${currentType === type.id
-                  ? 'bg-purple-50 text-purple-700'
-                  : 'text-gray-900 hover:bg-gray-50'
-                }
-                disabled:opacity-50 disabled:cursor-not-allowed
-              `}
-            >
-              <div className="font-bold text-sm">
-                {t(`sudokuTypes.${type.id}.name`)}
-              </div>
-              <div className="text-xs text-gray-500 mt-0.5">
-                {t(`sudokuTypes.${type.id}.description`)}
-              </div>
-            </button>
-          ))}
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onTypeChange(type.id);
+                    close();
+                  }
+                }}
+                disabled={disabled}
+                tabIndex={-1}
+                className={`
+                  w-full px-4 py-2.5 text-left transition-colors border-b border-gray-100 last:border-b-0
+                  ${currentType === type.id
+                    ? 'bg-purple-50 text-purple-700'
+                    : 'text-gray-900 hover:bg-gray-50'
+                  }
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                `}
+              >
+                <div className="font-bold text-sm">
+                  {t(`sudokuTypes.${type.id}.name`)}
+                </div>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  {t(`sudokuTypes.${type.id}.description`)}
+                </div>
+              </button>
+            ))}
+          </div>
+          {showScrollHint && (
+            <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent rounded-b-lg pointer-events-none" />
+          )}
         </div>
       )}
     </div>

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -369,6 +369,11 @@ export function GameContainer() {
               <h2 className="text-sm font-medium text-gray-600 mb-3 text-center">
                 {t('game.numberInput')}
               </h2>
+              {!state.selectedCell && state.gameStatus === GAME_STATUS.PLAYING && (
+                <p className="text-xs text-blue-500 mb-3 text-center">
+                  {t('game.selectCellHint')}
+                </p>
+              )}
               <div className="flex justify-center">
                 <NumberPad
                   onNumberClick={handleNumberClick}

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -369,11 +369,13 @@ export function GameContainer() {
               <h2 className="text-sm font-medium text-gray-600 mb-3 text-center">
                 {t('game.numberInput')}
               </h2>
-              <p className="text-xs text-blue-500 mb-3 text-center" aria-live="polite">
-                {!state.selectedCell && state.gameStatus === GAME_STATUS.PLAYING
-                  ? t('game.selectCellHint')
-                  : ''}
-              </p>
+              <div className="min-h-[1.25rem] mb-2" aria-live="polite">
+                {!state.selectedCell && state.gameStatus === GAME_STATUS.PLAYING && (
+                  <p className="text-xs text-blue-500 text-center" role="status">
+                    {t('game.selectCellHint')}
+                  </p>
+                )}
+              </div>
               <div className="flex justify-center">
                 <NumberPad
                   onNumberClick={handleNumberClick}

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -369,11 +369,11 @@ export function GameContainer() {
               <h2 className="text-sm font-medium text-gray-600 mb-3 text-center">
                 {t('game.numberInput')}
               </h2>
-              {!state.selectedCell && state.gameStatus === GAME_STATUS.PLAYING && (
-                <p className="text-xs text-blue-500 mb-3 text-center" aria-live="polite">
-                  {t('game.selectCellHint')}
-                </p>
-              )}
+              <p className="text-xs text-blue-500 mb-3 text-center" aria-live="polite">
+                {!state.selectedCell && state.gameStatus === GAME_STATUS.PLAYING
+                  ? t('game.selectCellHint')
+                  : ''}
+              </p>
               <div className="flex justify-center">
                 <NumberPad
                   onNumberClick={handleNumberClick}

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -370,7 +370,7 @@ export function GameContainer() {
                 {t('game.numberInput')}
               </h2>
               {!state.selectedCell && state.gameStatus === GAME_STATUS.PLAYING && (
-                <p className="text-xs text-blue-500 mb-3 text-center">
+                <p className="text-xs text-blue-500 mb-3 text-center" aria-live="polite">
                   {t('game.selectCellHint')}
                 </p>
               )}

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -371,7 +371,7 @@ export function GameContainer() {
               </h2>
               <div className="min-h-[1.25rem] mb-2" aria-live="polite">
                 {!state.selectedCell && state.gameStatus === GAME_STATUS.PLAYING && (
-                  <p className="text-xs text-blue-500 text-center" role="status">
+                  <p className="text-xs text-blue-500 text-center">
                     {t('game.selectCellHint')}
                   </p>
                 )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -12,6 +12,7 @@
     "type": "Type:",
     "difficulty": "Difficulty:",
     "numberInput": "Number Input:",
+    "selectCellHint": "Select a cell to enter a number",
     "paused": "Game Paused",
     "completed": "🎉 Congratulations! You solved the puzzle!",
     "hintsUsed": "{{used}}/{{max}}",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -12,6 +12,7 @@
     "type": "Тип:",
     "difficulty": "Сложность:",
     "numberInput": "Ввод чисел:",
+    "selectCellHint": "Выберите ячейку для ввода числа",
     "paused": "Игра на паузе",
     "completed": "🎉 Поздравляем! Вы решили головоломку!",
     "hintsUsed": "{{used}}/{{max}}",


### PR DESCRIPTION
## Summary
- **#44**: Type selector dropdown now shows a bottom fade gradient indicating more types are available below. Disappears when scrolled to bottom.
- **#45**: Number pad area shows "Select a cell to enter a number" hint when no cell is selected during active gameplay.
- Updates SudokuTypeSelector unit tests for the unified dropdown component.

Closes #44, closes #45

## Test plan
- [ ] Open type selector dropdown, verify fade gradient visible at bottom
- [ ] Scroll to bottom of dropdown, verify fade disappears
- [ ] Start game without selecting a cell, verify hint text above number pad
- [ ] Select a cell, verify hint text disappears
- [ ] Run `npx vitest run --config vitest.unit.config.ts` — all pass
- [ ] Check both EN and RU translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)