### PR TITLE
ci: make Claude PR review post mandatory + allow file reads

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -46,8 +46,24 @@ jobs:
              approaches the author already defended.
           2. Run `gh pr diff ${{ github.event.pull_request.number }}` to see the changes.
              Review ONLY what the diff shows. Do not audit unchanged code, do not crawl
-             the broader codebase looking for things to flag.
-          3. Post your review with `gh pr comment ${{ github.event.pull_request.number }} --body "..."`.
+             the broader codebase looking for things to flag. You MAY use `Read` / `Grep`
+             / `Glob` on files touched by the diff to verify a finding before reporting it,
+             but stay within the diff scope.
+          3. **MANDATORY FINAL STEP** — Post your review with
+             `gh pr comment ${{ github.event.pull_request.number }} --body "..."`.
+             You MUST post exactly one comment before ending your turn, no exceptions.
+             If you have nothing to flag after the analysis above, post this exact body:
+
+             ```
+             **Summary** — <one sentence on what the PR does>
+
+             No Critical, Important, or Suggestions to flag. Diff looks clean.
+
+             **Testing** — <1–2 things to manually verify>
+             ```
+
+             Do not end your turn without posting. A turn that ends with no `gh pr comment`
+             call is a failed review.
 
           ## What to look for (in order of priority)
 
@@ -105,4 +121,4 @@ jobs:
 
           See the CLAUDE.md file in the repository for project context.
 
-        claude_args: '--allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr list:*)"'
+        claude_args: '--allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr list:*),Read,Grep,Glob"'


### PR DESCRIPTION
## Summary
PR #74 surfaced two bugs in our Claude PR review workflow: the run finished green but never posted a review.

- **11 permission denials.** The allow-list only had `gh pr` bash commands. The prompt told the model to "see CLAUDE.md for project context" and to verify findings, so it tried `Read` on CLAUDE.md and source files → all denied. After burning ~25 turns it gave up.
- **Posting was a step, not a requirement.** The prompt said "post your review" but didn't enforce it. When the model hit denials and then concluded there was nothing critical to flag, it ended its turn silently.

## Fix
- Add `Read`, `Grep`, `Glob` to `--allowed-tools`. Diff scope still enforced by the prompt ("stay within the diff scope").
- Make `gh pr comment` a **MANDATORY FINAL STEP** with an explicit fallback body for clean PRs ("No Critical, Important, or Suggestions to flag.") so the model has a known-good answer when there's nothing to flag.

## Test plan
- [ ] Merge to dev
- [ ] Re-run review on PR #74 (or wait for the next PR) and verify a comment shows up
- [ ] Confirm `permission_denials_count` drops from 11 to 0–1 in the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)