### PR TITLE
fix(streak): future-date guard + drop unbounded completedDates array

### DIFF
--- a/src/utils/dailyPuzzle.test.ts
+++ b/src/utils/dailyPuzzle.test.ts
@@ -5,6 +5,7 @@ import {
   recordDailyCompletion,
   getDailyStreak,
   toDateString,
+  toDayNumber,
   loadDailyStore,
 } from './dailyPuzzle';
 
@@ -16,6 +17,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe('getDailyInfo', () => {
@@ -51,6 +53,62 @@ describe('getDailyInfo', () => {
     const d1 = getDailyInfo(new Date(2024, 0, 1));
     const d2 = getDailyInfo(new Date(2024, 0, 2));
     expect(d2.dayNumber - d1.dayNumber).toBe(1);
+  });
+});
+
+describe('toDayNumber / toDateString consistency (#144 false-positive guard)', () => {
+  // Issue #144 claimed toDateString (local) and toDayNumber (allegedly UTC)
+  // describe different days near midnight. They don't — both are rooted in
+  // the user's LOCAL calendar day. These tests pin the invariant so future
+  // refactors don't accidentally introduce the drift codex hypothesized.
+
+  it('agree at noon (no edge case)', () => {
+    const d = new Date(2024, 5, 15, 12, 0, 0);
+    expect(toDateString(d)).toBe('2024-06-15');
+    // The same call run a second time should give the same dayNumber.
+    expect(toDayNumber(d)).toBe(toDayNumber(new Date(2024, 5, 15, 12, 0, 0)));
+  });
+
+  it('agree at 23:30 local (the case codex claimed would mismatch)', () => {
+    const d = new Date(2024, 5, 15, 23, 30, 0);
+    expect(toDateString(d)).toBe('2024-06-15');
+    // Same dayNumber as noon on the same local day.
+    expect(toDayNumber(d)).toBe(toDayNumber(new Date(2024, 5, 15, 12, 0, 0)));
+  });
+
+  it('agree at 00:30 local (start of day)', () => {
+    const d = new Date(2024, 5, 15, 0, 30, 0);
+    expect(toDateString(d)).toBe('2024-06-15');
+    expect(toDayNumber(d)).toBe(toDayNumber(new Date(2024, 5, 15, 12, 0, 0)));
+  });
+
+  it('roll over together at midnight', () => {
+    const beforeMidnight = new Date(2024, 5, 15, 23, 59, 59);
+    const afterMidnight = new Date(2024, 5, 16, 0, 0, 1);
+    expect(toDateString(beforeMidnight)).toBe('2024-06-15');
+    expect(toDateString(afterMidnight)).toBe('2024-06-16');
+    expect(toDayNumber(afterMidnight) - toDayNumber(beforeMidnight)).toBe(1);
+  });
+});
+
+describe('DST safety (#136 false-positive guard)', () => {
+  // Issue #136 worried that setDate(getDate()-1) would break across DST
+  // transitions. JS Date arithmetic on local days is DST-safe (the spec
+  // normalizes wall-clock days, not 24h chunks). These tests pin the
+  // behavior so a future refactor can't regress it.
+
+  it('records consecutive completions across spring-forward (US 2024-03-10)', () => {
+    // 2024-03-09 (Sat) and 2024-03-10 (Sun, spring-forward in US)
+    recordDailyCompletion(new Date(2024, 2, 9, 12, 0));
+    const store = recordDailyCompletion(new Date(2024, 2, 10, 12, 0));
+    expect(store.currentStreak).toBe(2);
+  });
+
+  it('records consecutive completions across fall-back (US 2024-11-03)', () => {
+    // 2024-11-02 (Sat) and 2024-11-03 (Sun, fall-back in US)
+    recordDailyCompletion(new Date(2024, 10, 2, 12, 0));
+    const store = recordDailyCompletion(new Date(2024, 10, 3, 12, 0));
+    expect(store.currentStreak).toBe(2);
   });
 });
 
@@ -108,6 +166,41 @@ describe('recordDailyCompletion', () => {
   });
 });
 
+describe('clock-back exploit guard (#142)', () => {
+  it('does NOT inflate streak when clock rolls back', () => {
+    // Step 1: user "travels" to tomorrow and completes.
+    recordDailyCompletion(new Date(2024, 0, 16));
+    expect(loadDailyStore().currentStreak).toBe(1);
+    expect(loadDailyStore().lastCompletedDayNumber).toBeGreaterThan(0);
+
+    // Step 2: user rolls clock back to today and tries to complete again.
+    // The future-date guard should detect this and reset to a fresh
+    // single-day streak instead of letting the user farm increments.
+    const store = recordDailyCompletion(new Date(2024, 0, 15));
+    expect(store.currentStreak).toBe(1); // not 2
+    // The stored date is now today (post-rollback), not tomorrow.
+    expect(store.lastCompletedDayNumber).toBe(
+      Math.floor(
+        (Date.UTC(2024, 0, 15) - Date.UTC(2000, 0, 1)) / 86_400_000,
+      ),
+    );
+  });
+
+  it('preserves bestStreak through a clock-back reset', () => {
+    // Build up a real streak first.
+    recordDailyCompletion(new Date(2024, 0, 10));
+    recordDailyCompletion(new Date(2024, 0, 11));
+    recordDailyCompletion(new Date(2024, 0, 12));
+    expect(loadDailyStore().bestStreak).toBe(3);
+
+    // Future date.
+    recordDailyCompletion(new Date(2024, 0, 14));
+    // Clock-back attempt.
+    const store = recordDailyCompletion(new Date(2024, 0, 13));
+    expect(store.bestStreak).toBe(3); // not lost
+  });
+});
+
 describe('getDailyStreak', () => {
   it('returns 0 when no completions', () => {
     const streak = getDailyStreak();
@@ -136,13 +229,105 @@ describe('loadDailyStore', () => {
   it('returns empty store when localStorage is empty', () => {
     const store = loadDailyStore();
     expect(store.currentStreak).toBe(0);
-    expect(store.completedDates).toHaveLength(0);
+    expect(store.lastCompletedDayNumber).toBeNull();
   });
 
-  it('returns empty store when stored version mismatches', () => {
+  it('returns empty store when stored version mismatches (forward-incompat)', () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 99, currentStreak: 5 }));
     const store = loadDailyStore();
     expect(store.currentStreak).toBe(0);
+  });
+});
+
+describe('v1 → v2 migration (#137)', () => {
+  // v1 stored `lastCompletedDate: string` (YYYY-MM-DD) and
+  // `completedDates: string[]`. v2 stores `lastCompletedDayNumber: number`.
+  // Migration must preserve currentStreak, bestStreak, and the
+  // last-completed information so users don't lose their streak on upgrade.
+
+  it('preserves currentStreak and bestStreak from a v1 store', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        currentStreak: 7,
+        bestStreak: 12,
+        lastCompletedDate: '2024-06-15',
+        completedDates: ['2024-06-13', '2024-06-14', '2024-06-15'],
+      }),
+    );
+    const store = loadDailyStore();
+    expect(store.version).toBe(2);
+    expect(store.currentStreak).toBe(7);
+    expect(store.bestStreak).toBe(12);
+  });
+
+  it('converts lastCompletedDate string to a dayNumber that round-trips', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        currentStreak: 1,
+        bestStreak: 1,
+        lastCompletedDate: '2024-06-15',
+        completedDates: ['2024-06-15'],
+      }),
+    );
+    const store = loadDailyStore();
+    // The migrated dayNumber should match toDayNumber for the same date.
+    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 5, 15)));
+  });
+
+  it('lets a user continue their streak immediately after migration', () => {
+    // User had a streak of 5 ending yesterday; today they complete again.
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        currentStreak: 5,
+        bestStreak: 5,
+        lastCompletedDate: toDateString(yesterday),
+        completedDates: [toDateString(yesterday)],
+      }),
+    );
+    const store = recordDailyCompletion(new Date());
+    expect(store.currentStreak).toBe(6);
+  });
+
+  it('persists the migrated form so subsequent loads do not re-migrate', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        currentStreak: 3,
+        bestStreak: 3,
+        lastCompletedDate: '2024-06-15',
+        completedDates: ['2024-06-15'],
+      }),
+    );
+    loadDailyStore(); // triggers migration + save
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!) as Record<string, unknown>;
+    expect(parsed.version).toBe(2);
+    expect(parsed.completedDates).toBeUndefined();
+    expect(typeof parsed.lastCompletedDayNumber).toBe('number');
+  });
+
+  it('handles a v1 store with missing lastCompletedDate gracefully', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        currentStreak: 0,
+        bestStreak: 0,
+        completedDates: [],
+      }),
+    );
+    const store = loadDailyStore();
+    expect(store.lastCompletedDayNumber).toBeNull();
   });
 });
 

--- a/src/utils/dailyPuzzle.test.ts
+++ b/src/utils/dailyPuzzle.test.ts
@@ -179,11 +179,7 @@ describe('clock-back exploit guard (#142)', () => {
     const store = recordDailyCompletion(new Date(2024, 0, 15));
     expect(store.currentStreak).toBe(1); // not 2
     // The stored date is now today (post-rollback), not tomorrow.
-    expect(store.lastCompletedDayNumber).toBe(
-      Math.floor(
-        (Date.UTC(2024, 0, 15) - Date.UTC(2000, 0, 1)) / 86_400_000,
-      ),
-    );
+    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 15)));
   });
 
   it('preserves bestStreak through a clock-back reset', () => {

--- a/src/utils/dailyPuzzle.ts
+++ b/src/utils/dailyPuzzle.ts
@@ -170,6 +170,10 @@ function saveDailyStore(store: DailyStore): void {
   }
 }
 
+// Only the most recent completion is stored (since v2 — see migrateFromV1).
+// This is NOT a full-history lookup. If you ever need "did the user ever
+// complete day N?", you'll need a different storage shape — don't reach
+// for lastCompletedDayNumber and silently get the wrong answer.
 export function isDailyCompleted(date = new Date()): boolean {
   const store = loadDailyStore();
   return store.lastCompletedDayNumber === toDayNumber(date);

--- a/src/utils/dailyPuzzle.ts
+++ b/src/utils/dailyPuzzle.ts
@@ -1,7 +1,7 @@
 import type { SudokuTypeId, DifficultyLevel } from '../types/index';
 
 const DAILY_STORAGE_KEY = 'sudoku-daily';
-const DAILY_STORE_VERSION = 1;
+const DAILY_STORE_VERSION = 2;
 
 // Ordered list of variant types used in daily rotation.
 const DAILY_TYPES: SudokuTypeId[] = [
@@ -31,11 +31,13 @@ const DOW_DIFFICULTY: DifficultyLevel[] = [
   'EXPERT', // Sat
 ];
 
-// UTC epoch for stable day-number calculation regardless of local timezone.
+// Anchor for day-number arithmetic. Using Date.UTC keeps the constant
+// timezone-independent so the same dayNumber math works regardless of the
+// runtime locale.
 const EPOCH_UTC = Date.UTC(2000, 0, 1);
 
 export interface DailyInfo {
-  date: string;       // YYYY-MM-DD
+  date: string;       // YYYY-MM-DD (local calendar day)
   dayNumber: number;  // days since 2000-01-01 (used as puzzle #N)
   seed: number;
   type: SudokuTypeId;
@@ -46,18 +48,35 @@ export interface DailyStore {
   version: number;
   currentStreak: number;
   bestStreak: number;
-  lastCompletedDate: string | null;
-  completedDates: string[];
+  // Day-number form. null = no completion ever recorded.
+  lastCompletedDayNumber: number | null;
 }
 
+// Date helpers — IMPORTANT: both functions are rooted in the user's LOCAL
+// calendar day. We deliberately call getFullYear/getMonth/getDate (local
+// accessors) and pass them into Date.UTC. The Date.UTC call is just a
+// convenient way to produce a timezone-stable integer for "midnight on the
+// local Y/M/D"; it does NOT mean we're operating in UTC. Both functions
+// always agree for the same input Date — they describe the same local day.
+//
+// Trade-off: streaks are tracked against the user's local calendar day, so
+// they survive DST (Date arithmetic on local days is DST-safe) but a user
+// who travels across the international date line in the same wall-clock
+// instant can see their streak reset. That's a documented limitation —
+// fixing it requires server-side time, which this static SPA does not have.
 export function toDateString(date: Date): string {
+  // YYYY-MM-DD for the user's LOCAL calendar day.
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
   const d = String(date.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
 }
 
-function toDayNumber(date: Date): number {
+export function toDayNumber(date: Date): number {
+  // Stable integer ID for the user's LOCAL calendar day.
+  // We feed local Y/M/D into Date.UTC so the result is independent of the
+  // user's timezone offset — Apr 25 in PT and Apr 25 in ET produce the
+  // same integer, even though the underlying Date timestamps differ.
   const utcMs = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
   return Math.floor((utcMs - EPOCH_UTC) / 86_400_000);
 }
@@ -77,8 +96,34 @@ function emptyStore(): DailyStore {
     version: DAILY_STORE_VERSION,
     currentStreak: 0,
     bestStreak: 0,
-    lastCompletedDate: null,
-    completedDates: [],
+    lastCompletedDayNumber: null,
+  };
+}
+
+// Migrate a v1 store (which used `lastCompletedDate: string` and a
+// `completedDates: string[]` array) into v2 form. We preserve currentStreak
+// and bestStreak exactly, and convert the date string into a dayNumber.
+// The `completedDates` array is dropped — it was only ever used for
+// idempotency on duplicate completions, which lastCompletedDayNumber now
+// handles in O(1).
+function migrateFromV1(raw: Record<string, unknown>): DailyStore {
+  let lastDayNumber: number | null = null;
+  if (typeof raw.lastCompletedDate === 'string') {
+    const m = raw.lastCompletedDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (m) {
+      const [, y, mo, d] = m;
+      // The v1 string was produced by toDateString (local calendar day).
+      // Round-trip via Date.UTC to get the same integer toDayNumber would.
+      lastDayNumber = Math.floor(
+        (Date.UTC(Number(y), Number(mo) - 1, Number(d)) - EPOCH_UTC) / 86_400_000,
+      );
+    }
+  }
+  return {
+    version: DAILY_STORE_VERSION,
+    currentStreak: typeof raw.currentStreak === 'number' ? raw.currentStreak : 0,
+    bestStreak: typeof raw.bestStreak === 'number' ? raw.bestStreak : 0,
+    lastCompletedDayNumber: lastDayNumber,
   };
 }
 
@@ -87,12 +132,19 @@ export function loadDailyStore(): DailyStore {
     const raw = localStorage.getItem(DAILY_STORAGE_KEY);
     if (!raw) return emptyStore();
     const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+    // v1 → v2 migration. v1 had `lastCompletedDate: string` + `completedDates: string[]`.
+    if (parsed.version === 1) {
+      const migrated = migrateFromV1(parsed);
+      saveDailyStore(migrated);
+      return migrated;
+    }
+
     if (parsed.version !== DAILY_STORE_VERSION) return emptyStore();
     // Validate required fields to guard against corrupt/partial data.
     if (
       typeof parsed.currentStreak !== 'number' ||
-      typeof parsed.bestStreak !== 'number' ||
-      !Array.isArray(parsed.completedDates)
+      typeof parsed.bestStreak !== 'number'
     ) {
       return emptyStore();
     }
@@ -100,12 +152,10 @@ export function loadDailyStore(): DailyStore {
       version: DAILY_STORE_VERSION,
       currentStreak: parsed.currentStreak,
       bestStreak: parsed.bestStreak,
-      lastCompletedDate: typeof parsed.lastCompletedDate === 'string'
-        ? parsed.lastCompletedDate
-        : null,
-      completedDates: (parsed.completedDates as unknown[]).filter(
-        (d): d is string => typeof d === 'string',
-      ),
+      lastCompletedDayNumber:
+        typeof parsed.lastCompletedDayNumber === 'number'
+          ? parsed.lastCompletedDayNumber
+          : null,
     };
   } catch {
     return emptyStore();
@@ -122,27 +172,45 @@ function saveDailyStore(store: DailyStore): void {
 
 export function isDailyCompleted(date = new Date()): boolean {
   const store = loadDailyStore();
-  return store.completedDates.includes(toDateString(date));
+  return store.lastCompletedDayNumber === toDayNumber(date);
 }
 
 export function recordDailyCompletion(date = new Date()): DailyStore {
-  const dateStr = toDateString(date);
+  const today = toDayNumber(date);
   const store = loadDailyStore();
 
-  if (store.completedDates.includes(dateStr)) return store;
+  // Future-date guard: if the stored "last completed" is in the future
+  // relative to the system clock, the user has rolled their clock back
+  // (either intentionally to farm streaks, or via NTP / dead RTC battery).
+  // Reset to a fresh single-day streak — neither rewarding the cheat nor
+  // punishing the honest user beyond a one-day streak loss.
+  if (store.lastCompletedDayNumber !== null && store.lastCompletedDayNumber > today) {
+    const reset: DailyStore = {
+      ...store,
+      currentStreak: 1,
+      bestStreak: Math.max(store.bestStreak, 1),
+      lastCompletedDayNumber: today,
+    };
+    saveDailyStore(reset);
+    return reset;
+  }
 
-  const yesterday = new Date(date);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const newStreak = store.lastCompletedDate === toDateString(yesterday)
-    ? store.currentStreak + 1
-    : 1;
+  // Idempotent: re-recording the same day is a no-op (e.g. user solves the
+  // puzzle twice in the same session, or a duplicate event fires).
+  if (store.lastCompletedDayNumber === today) return store;
+
+  // Streak math: consecutive day = today - 1 in dayNumber arithmetic.
+  // Anything else (gap, never-completed) resets to 1.
+  const newStreak =
+    store.lastCompletedDayNumber === today - 1
+      ? store.currentStreak + 1
+      : 1;
 
   const updated: DailyStore = {
     ...store,
     currentStreak: newStreak,
     bestStreak: Math.max(store.bestStreak, newStreak),
-    lastCompletedDate: dateStr,
-    completedDates: [...store.completedDates, dateStr],
+    lastCompletedDayNumber: today,
   };
 
   saveDailyStore(updated);
@@ -151,13 +219,12 @@ export function recordDailyCompletion(date = new Date()): DailyStore {
 
 export function getDailyStreak(): { current: number; best: number } {
   const store = loadDailyStore();
-  const today = new Date();
-  const todayStr = toDateString(today);
-  const yesterday = new Date(today);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const streakActive =
-    store.lastCompletedDate === todayStr ||
-    store.lastCompletedDate === toDateString(yesterday);
+  const today = toDayNumber(new Date());
+  // A streak is "active" if the last completion was today or yesterday;
+  // otherwise we display 0 (without zeroing the stored value — bestStreak
+  // and the next consecutive completion can still pick it up).
+  const last = store.lastCompletedDayNumber;
+  const streakActive = last === today || last === today - 1;
   return {
     current: streakActive ? store.currentStreak : 0,
     best: store.bestStreak,


### PR DESCRIPTION
## Summary

- **Closes #142** — clock-back exploit fixed via future-date guard
- **Closes #137** — unbounded `completedDates` array replaced with `lastCompletedDayNumber: number`
- **Confirms #136 + #144 as false positives** — kept tests as regression guards, will close those issues with explanation

This is the first issue in the **timezone cluster** identified by `/codex challenge`. After detailed code analysis I found that 2 of the 4 cluster issues weren't actually bugs:

| Issue | Verdict | Action |
|---|---|---|
| #142 clock-back exploit | **REAL** — no future-date guard | Fixed: future-date guard in `recordDailyCompletion` |
| #137 unbounded `completedDates` | **REAL** — array grew forever, JSON.parse cost compounds | Fixed: dropped array, use `lastCompletedDayNumber` for O(1) idempotency |
| #136 DST + timezone travel | **FALSE POSITIVE (DST)** | `setDate(getDate()-1)` is DST-safe per JS spec. Tests pin the behavior. Travel across IDL is real but requires server-side time to fix; documented in code comment. |
| #144 UTC vs local mismatch | **FALSE POSITIVE** | Codex misread the code. Both `toDateString` and `toDayNumber` are rooted in the user's LOCAL calendar day; the `Date.UTC` call is a trick to produce a timezone-stable integer, not a switch to UTC semantics. Tests pin the invariant. |

## What changed

- `src/utils/dailyPuzzle.ts`:
  - Store version 1 → 2 with v1→v2 migration
  - `completedDates: string[]` + `lastCompletedDate: string` → `lastCompletedDayNumber: number | null`
  - Future-date guard in `recordDailyCompletion`
  - Heavy comments explaining the LOCAL-calendar-day rooting of `toDateString` and `toDayNumber` so future maintainers don't accidentally reintroduce the drift codex hypothesized

- `src/utils/dailyPuzzle.test.ts` (+178 lines):
  - 2 tests for clock-back guard
  - 2 tests for DST safety (US 2024 spring-forward + fall-back)
  - 4 tests for `toDayNumber` / `toDateString` consistency
  - 5 tests for v1 → v2 migration

## What was NOT changed

- `src/hooks/useDaily.ts` — the `markCompleted(date)` flow correctly records against the puzzle's date, not wall-clock at solve. The separate stale-dailyInfo UX bug from #138 ships in `fix/daily-info-midnight-refresh`.
- `src/components/UI/StreakBanner.tsx` — already fixed in #108 for countdown DST safety + zero-clamp.

## Test plan

- [x] 32/32 `dailyPuzzle` tests pass
- [x] Full unit suite passes (305+ tests)
- [x] No new TypeScript errors
- [x] `eslint` clean
- [ ] Manual verification on a v1 store: load app, verify migration runs once and currentStreak/bestStreak preserved

## Migration notes

Existing users on v1 stores will silently migrate on their next load. If they completed yesterday and play today, their streak continues correctly. The `completedDates` array is dropped — it was only used for idempotency, which `lastCompletedDayNumber` now handles in O(1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)