### PR TITLE
fix(daily): refresh dailyInfo at midnight + on visibility change

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -56,6 +56,10 @@ export function GameContainer() {
   const [statsOpen, setStatsOpen] = useState(false);
   const [isPlayingDaily, setIsPlayingDaily] = useState(false);
   const isPlayingDailyRef = useRef(false);
+  // Captured at game start. Used at completion instead of dailyInfo.date so
+  // a midnight rollover mid-game records against the day the puzzle was
+  // started, not the day it was solved on.
+  const playingDailyDateRef = useRef<string | null>(null);
 
   const [shareToastVisible, setShareToastVisible] = useState(false);
 
@@ -88,9 +92,10 @@ export function GameContainer() {
     if (state.gameStatus === GAME_STATUS.COMPLETED && prevStatus !== GAME_STATUS.COMPLETED) {
       isNewBestTimeRef.current = updateBestTime(state.difficulty, state.elapsedTime);
       recordGameComplete(state.sudokuType, state.difficulty, state.elapsedTime, state.mistakeCount);
-      if (isPlayingDailyRef.current) {
-        markDailyCompleted(dailyInfo.date);
+      if (isPlayingDailyRef.current && playingDailyDateRef.current) {
+        markDailyCompleted(playingDailyDateRef.current);
         isPlayingDailyRef.current = false;
+        playingDailyDateRef.current = null;
         setIsPlayingDaily(false);
       }
       playVictorySound();
@@ -110,7 +115,10 @@ export function GameContainer() {
 
     prevGameStatusRef.current = state.gameStatus;
     prevErrorsSizeRef.current = state.errors.size;
-  }, [state.errors, state.gameStatus, state.elapsedTime, state.difficulty, state.sudokuType, state.mistakeCount, dailyInfo.date, markDailyCompleted, playVictorySound, playErrorSound, playDigitSound, vibrateComplete, vibrateError, vibrateDigit]);
+    // dailyInfo.date intentionally NOT in deps — completion uses the captured
+    // playingDailyDateRef so midnight refresh of dailyInfo doesn't change which
+    // day gets credited.
+  }, [state.errors, state.gameStatus, state.elapsedTime, state.difficulty, state.sudokuType, state.mistakeCount, markDailyCompleted, playVictorySound, playErrorSound, playDigitSound, vibrateComplete, vibrateError, vibrateDigit]);
 
   // Confetti on completion — declared AFTER the sound effect so React runs it
   // second, giving the sound effect a chance to update isNewBestTimeRef first.
@@ -267,6 +275,7 @@ export function GameContainer() {
 
   const handleNewGame = useCallback(() => {
     isPlayingDailyRef.current = false;
+    playingDailyDateRef.current = null;
     setIsPlayingDaily(false);
     actions.newGame(state.difficulty, state.sudokuType);
     recordGameStart(state.sudokuType, state.difficulty);
@@ -274,6 +283,9 @@ export function GameContainer() {
 
   const handleStartDaily = useCallback(() => {
     isPlayingDailyRef.current = true;
+    // Snapshot the puzzle's date NOW so a midnight rollover during play
+    // doesn't change which day completion credits.
+    playingDailyDateRef.current = dailyInfo.date;
     setIsPlayingDaily(true);
     actions.newGame(dailyInfo.difficulty, dailyInfo.type, dailyInfo.seed);
     recordGameStart(dailyInfo.type, dailyInfo.difficulty);
@@ -300,6 +312,7 @@ export function GameContainer() {
         !window.confirm(t('game.confirmNewGame'))
       ) return;
       isPlayingDailyRef.current = false;
+      playingDailyDateRef.current = null;
       setIsPlayingDaily(false);
       actions.newGame(difficulty, state.sudokuType);
       if (difficulty) recordGameStart(state.sudokuType, difficulty);
@@ -315,6 +328,7 @@ export function GameContainer() {
         !window.confirm(t('game.confirmNewGame'))
       ) return;
       isPlayingDailyRef.current = false;
+      playingDailyDateRef.current = null;
       setIsPlayingDaily(false);
       actions.newGame(state.difficulty, sudokuType);
       if (sudokuType) {

--- a/src/hooks/useDaily.test.ts
+++ b/src/hooks/useDaily.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDaily } from './useDaily';
+import { recordDailyCompletion } from '../utils/dailyPuzzle';
+
+const DAILY_STORAGE_KEY = 'sudoku-daily';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('useDaily — initial render', () => {
+  it('returns dailyInfo for today', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.dailyInfo.date).toBe('2024-06-15');
+  });
+
+  it('returns isCompleted=false when not completed', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.isCompleted).toBe(false);
+  });
+
+  it('returns isCompleted=true when today is recorded', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    recordDailyCompletion(new Date(2024, 5, 15));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.isCompleted).toBe(true);
+  });
+
+  it('returns 0 streak with no completions', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.streak.current).toBe(0);
+  });
+});
+
+describe('useDaily — midnight rollover (#138)', () => {
+  it('refreshes dailyInfo when local midnight passes', () => {
+    // Mount at 23:59:50 on Jun 15
+    vi.setSystemTime(new Date(2024, 5, 15, 23, 59, 50));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.dailyInfo.date).toBe('2024-06-15');
+    const oldDayNumber = result.current.dailyInfo.dayNumber;
+
+    // Fast-forward past midnight (15 seconds → 00:00:05 on Jun 16)
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+
+    // Hook should have re-scheduled and refreshed dailyInfo
+    expect(result.current.dailyInfo.date).toBe('2024-06-16');
+    expect(result.current.dailyInfo.dayNumber).toBe(oldDayNumber + 1);
+  });
+
+  it('does not refresh dailyInfo before midnight', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    const before = result.current.dailyInfo;
+
+    // Advance 11 hours (still on Jun 15)
+    act(() => {
+      vi.advanceTimersByTime(11 * 60 * 60 * 1000);
+    });
+
+    expect(result.current.dailyInfo).toBe(before);
+  });
+
+  it('refreshes again after a SECOND midnight passes', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 23, 59, 50));
+    const { result } = renderHook(() => useDaily());
+
+    // Cross first midnight → Jun 16
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(result.current.dailyInfo.date).toBe('2024-06-16');
+
+    // Cross second midnight → Jun 17
+    act(() => {
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    });
+    expect(result.current.dailyInfo.date).toBe('2024-06-17');
+  });
+
+  it('refreshes isCompleted when day rolls over', () => {
+    // Today (Jun 15) is recorded as completed
+    vi.setSystemTime(new Date(2024, 5, 15, 23, 59, 50));
+    recordDailyCompletion(new Date(2024, 5, 15));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.isCompleted).toBe(true);
+
+    // After midnight, today is now Jun 16 — not yet completed
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(result.current.isCompleted).toBe(false);
+  });
+});
+
+describe('useDaily — visibility-change safety net (#138)', () => {
+  it('refreshes dailyInfo when tab becomes visible after a system sleep', () => {
+    // Mount at 22:00 on Jun 15
+    vi.setSystemTime(new Date(2024, 5, 15, 22, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.dailyInfo.date).toBe('2024-06-15');
+
+    // Simulate the system sleeping past midnight without setTimeout firing.
+    // We jump the system clock without advancing fake timers.
+    vi.setSystemTime(new Date(2024, 5, 16, 9, 30, 0));
+
+    // Tab becomes visible — visibility-change handler fires
+    act(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'visible',
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(result.current.dailyInfo.date).toBe('2024-06-16');
+  });
+
+  it('does NOT refresh when tab visibility changes but day has not changed', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    const before = result.current.dailyInfo;
+
+    act(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'visible',
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // Same dayNumber → same reference (state updater returned prev)
+    expect(result.current.dailyInfo).toBe(before);
+  });
+});
+
+describe('useDaily — markCompleted', () => {
+  it('records completion against the puzzle date passed in', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+
+    act(() => {
+      result.current.markCompleted('2024-06-15');
+    });
+
+    expect(result.current.isCompleted).toBe(true);
+    expect(result.current.streak.current).toBe(1);
+    // localStorage state should reflect the completion
+    const store = JSON.parse(localStorage.getItem(DAILY_STORAGE_KEY)!);
+    expect(store.currentStreak).toBe(1);
+  });
+
+  it('records against yesterday when the puzzle was started yesterday and completed past midnight', () => {
+    // Mount at 23:59 on Jun 15. User starts puzzle, captures '2024-06-15'.
+    vi.setSystemTime(new Date(2024, 5, 15, 23, 59, 0));
+    const { result } = renderHook(() => useDaily());
+    const startedDate = result.current.dailyInfo.date;
+    expect(startedDate).toBe('2024-06-15');
+
+    // Now advance past midnight to 00:01 Jun 16
+    act(() => {
+      vi.advanceTimersByTime(2 * 60 * 1000);
+    });
+    // dailyInfo refreshed to Jun 16
+    expect(result.current.dailyInfo.date).toBe('2024-06-16');
+
+    // BUT user is completing the puzzle they started YESTERDAY — they
+    // pass the captured-at-start date, not the current dailyInfo.date.
+    act(() => {
+      result.current.markCompleted(startedDate);
+    });
+
+    // Completion was recorded against yesterday (the day the puzzle ran for).
+    const store = JSON.parse(localStorage.getItem(DAILY_STORAGE_KEY)!);
+    // Day number for 2024-06-15 (yesterday relative to Jun 16)
+    const expectedDayNumber = Math.floor(
+      (Date.UTC(2024, 5, 15) - Date.UTC(2000, 0, 1)) / 86_400_000,
+    );
+    expect(store.lastCompletedDayNumber).toBe(expectedDayNumber);
+    expect(store.currentStreak).toBe(1);
+  });
+});
+
+describe('useDaily — cleanup', () => {
+  it('clears the midnight timeout on unmount', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 23, 59, 50));
+    const { result, unmount } = renderHook(() => useDaily());
+    expect(result.current.dailyInfo.date).toBe('2024-06-15');
+
+    unmount();
+
+    // Advance past midnight — without the cleanup, the setTimeout would
+    // fire and try to setState on an unmounted hook (not catastrophic in
+    // React 18+, but wasteful and a real-tab leak). Just verify no throw.
+    expect(() => {
+      vi.advanceTimersByTime(15_000);
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/useDaily.test.ts
+++ b/src/hooks/useDaily.test.ts
@@ -190,6 +190,11 @@ describe('useDaily — markCompleted', () => {
     );
     expect(store.lastCompletedDayNumber).toBe(expectedDayNumber);
     expect(store.currentStreak).toBe(1);
+
+    // The crucial UX assertion: TODAY's daily (Jun 16) is NOT marked
+    // completed — the user can still start it. isCompleted is queried
+    // against the current dailyInfo, which has rolled over to Jun 16.
+    expect(result.current.isCompleted).toBe(false);
   });
 });
 

--- a/src/hooks/useDaily.ts
+++ b/src/hooks/useDaily.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
   getDailyInfo,
   isDailyCompleted,
@@ -14,17 +14,82 @@ export interface UseDailyReturn {
   markCompleted: (date: string) => void;
 }
 
+// Milliseconds until the next local midnight. Computed via setDate(+1) +
+// setHours(0,0,0,0) which is DST-safe (JS Date arithmetic on local days
+// normalizes wall-clock days correctly).
+function msUntilNextMidnight(now: Date = new Date()): number {
+  const next = new Date(now);
+  next.setDate(next.getDate() + 1);
+  next.setHours(0, 0, 0, 0);
+  // Clamp to 0 in the unlikely case the system clock jumps past midnight
+  // between the `now` capture and this computation.
+  return Math.max(0, next.getTime() - now.getTime());
+}
+
 export function useDaily(): UseDailyReturn {
-  const [dailyInfo] = useState<DailyInfo>(() => getDailyInfo());
+  const [dailyInfo, setDailyInfo] = useState<DailyInfo>(() => getDailyInfo());
   const [isCompleted, setIsCompleted] = useState<boolean>(() => isDailyCompleted());
   const [streak, setStreak] = useState<{ current: number; best: number }>(() => getDailyStreak());
 
-  // Accept the puzzle's date string so completion is recorded against the day
-  // the puzzle was started, not the wall-clock time at solve (midnight-spanning fix).
+  // Refresh state if the local calendar day has rolled over since the
+  // last computation. Cheap to call repeatedly — it's a no-op when the
+  // dayNumber hasn't changed, so the visibility-change handler can fire
+  // it on every focus without triggering useless renders.
+  const refreshIfDayChanged = useCallback(() => {
+    setDailyInfo(prev => {
+      const fresh = getDailyInfo();
+      if (fresh.dayNumber === prev.dayNumber) return prev;
+      // Day rolled over — also refresh derived state.
+      setIsCompleted(isDailyCompleted());
+      setStreak(getDailyStreak());
+      return fresh;
+    });
+  }, []);
+
+  useEffect(() => {
+    // Schedule a refresh exactly at the next local midnight, then reschedule
+    // recursively. setTimeout is more accurate than a 1Hz interval (no drift,
+    // no wasted ticks) for a daily boundary.
+    let timeoutId: number;
+    const scheduleNext = () => {
+      timeoutId = window.setTimeout(() => {
+        refreshIfDayChanged();
+        scheduleNext();
+      }, msUntilNextMidnight());
+    };
+    scheduleNext();
+
+    // Visibility-change safety net: if the system slept past the scheduled
+    // midnight (laptop closed overnight), the setTimeout may not fire on
+    // wake. When the tab becomes visible we recompute and refresh if the
+    // day actually changed. Cheap no-op otherwise.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refreshIfDayChanged();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [refreshIfDayChanged]);
+
+  // Accept the puzzle's date string so completion is recorded against the
+  // day the puzzle was started, not the wall-clock time at solve. This is
+  // load-bearing: GameContainer captures dailyInfo.date in a ref AT GAME
+  // START so a midnight rollover mid-game doesn't credit the wrong day.
   const markCompleted = useCallback((date: string) => {
     recordDailyCompletion(new Date(date));
     setIsCompleted(true);
     setStreak(getDailyStreak());
+    // After completion, also refresh dailyInfo if the day rolled over
+    // during play — banner should reflect the new state correctly.
+    setDailyInfo(prev => {
+      const fresh = getDailyInfo();
+      return fresh.dayNumber === prev.dayNumber ? prev : fresh;
+    });
   }, []);
 
   return { dailyInfo, isCompleted, streak, markCompleted };

--- a/src/hooks/useDaily.ts
+++ b/src/hooks/useDaily.ts
@@ -82,10 +82,14 @@ export function useDaily(): UseDailyReturn {
   // START so a midnight rollover mid-game doesn't credit the wrong day.
   const markCompleted = useCallback((date: string) => {
     recordDailyCompletion(new Date(date));
-    setIsCompleted(true);
+    // Re-query rather than setIsCompleted(true) blindly. If the day rolled
+    // over while the puzzle was being solved, the user just completed
+    // YESTERDAY's puzzle — today's still needs to be playable, so isCompleted
+    // for the current dailyInfo should remain false.
+    setIsCompleted(isDailyCompleted());
     setStreak(getDailyStreak());
-    // After completion, also refresh dailyInfo if the day rolled over
-    // during play — banner should reflect the new state correctly.
+    // Same-day rollover refresh: if dailyInfo is still on the old day, pick
+    // up the new one so the banner reflects today's state correctly.
     setDailyInfo(prev => {
       const fresh = getDailyInfo();
       return fresh.dayNumber === prev.dayNumber ? prev : fresh;


### PR DESCRIPTION
## Summary

- **Closes #138** — refresh `dailyInfo` when local midnight passes, with a `visibilitychange` listener as the system-sleep safety net
- Captures `dailyInfo.date` in a ref at game start so a mid-game midnight rollover doesn't credit the wrong day on completion
- 13 new `useDaily` tests covering rollover, visibility, markCompleted-across-midnight, and cleanup

## Problem

Before: `useDaily` captured `dailyInfo` once at mount. Idle past midnight → banner stuck on yesterday's puzzle, "Play today" launches yesterday's puzzle.

## How it works

**`useDaily.ts`**
- `setTimeout(refresh, msUntilNextMidnight)` schedules the day boundary, fires once, then reschedules itself recursively. More accurate than a 1Hz interval (no drift).
- `visibilitychange` listener: if the OS suspended the timer (laptop closed overnight), the next tab-focus refreshes. Cheap no-op when the day hasn't actually changed.
- `markCompleted` now also refreshes `dailyInfo` after recording, so the banner flips to "completed" state correctly even if the day rolled over during play.

**`GameContainer.tsx`**
- New `playingDailyDateRef`. `handleStartDaily` snapshots `dailyInfo.date` into it. Completion effect reads from the ref, not from live `dailyInfo.date`. Mid-game rollover can't change which day gets credited.
- Ref is reset to `null` alongside `isPlayingDailyRef` in all the existing places (handleNewGame, handleDifficultyChange, handleTypeChange).

## Test plan

- [x] 13/13 `useDaily.test.ts` pass
- [x] 32/32 `dailyPuzzle.test.ts` still pass
- [x] Full unit suite passes
- [x] No new TypeScript errors
- [x] `eslint` clean
- [ ] Manual: open app at 23:59, leave open until 00:01, click "Play today" → verify it starts the NEW day's puzzle (different #N+1, possibly different variant)
- [ ] Manual: start the daily at 23:59, complete at 00:01 → verify completion credits yesterday (the day the puzzle ran for), not today

## Known follow-ups

The 1-second countdown re-render in `StreakBanner.tsx` (filed as part of #139) is unrelated to this fix and stays in its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)