### PR TITLE
fix: 5 typecheck errors + add typecheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ jobs:
       - run: npm ci
       - run: npx eslint .
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ If gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to bu
 ## Health Stack
 
 - lint: npx eslint .
+- typecheck: npx tsc --noEmit
 - test: npx vitest run --config vitest.unit.config.ts
 - e2e: npx playwright test
 - deadcode: npx knip

--- a/src/components/Controls/SudokuTypeSelector.test.tsx
+++ b/src/components/Controls/SudokuTypeSelector.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SudokuTypeSelector } from './SudokuTypeSelector';
 
@@ -76,12 +76,12 @@ describe('SudokuTypeSelector', () => {
       if (originalScrollHeight) {
         Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
       } else {
-        delete (HTMLElement.prototype as Record<string, unknown>).scrollHeight;
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>).scrollHeight;
       }
       if (originalClientHeight) {
         Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
       } else {
-        delete (HTMLElement.prototype as Record<string, unknown>).clientHeight;
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight;
       }
     }
 

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -11,7 +11,6 @@ import type {
   DifficultyLevel,
   SudokuTypeId,
   CellValue,
-  BoardSnapshot,
   OddEvenMarkers,
   KropkiDots,
   GreaterThanSigns,

--- a/src/context/GameProvider.test.tsx
+++ b/src/context/GameProvider.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import React, { useContext } from 'react';
-import { GameProvider, GameContext, Actions } from './GameContext';
+import { GameProvider, GameContext } from './GameContext';
 import { STORAGE_KEY } from '../utils/constants';
 
 // Minimal wrapper to access GameContext inside tests — re-renders on every state change


### PR DESCRIPTION
## Summary

- **Closes #114** — fixes the 5 `tsc --noEmit` errors that the v0.0.1.0 sprint accumulated
- **Adds a `typecheck` CI job** so this category of drift can't silently re-appear
- **Updates CLAUDE.md Health Stack** to include typecheck (so future `/health` audits cover it without manual adding)

## Errors fixed

| File:line | Code | Fix |
|---|---|---|
| `SudokuTypeSelector.test.tsx:1` (used at :88) | TS2304 `Cannot find name 'afterEach'` | Add `afterEach` to vitest import |
| `SudokuTypeSelector.test.tsx:79,84` | TS2352 `HTMLElement → Record<string, unknown>` | `as unknown as Record<string, unknown>` (standard escape hatch) |
| `GameContext.tsx:14` | TS6196 `'BoardSnapshot' declared but never used` | Remove unused import |
| `GameProvider.test.tsx:4` | TS6133 `'Actions' declared but value never read` | Remove unused import |

## Regression prevention

- New CI job `typecheck` runs `npx tsc --noEmit`. Without it, the only gate catching unused imports / unsafe casts was a developer manually running tsc.
- `CLAUDE.md` Health Stack now lists typecheck so `/health` includes it without manual override (the audit that found these had to add it on the fly).

## Test plan

- [x] `npx tsc --noEmit` → 0 errors (was 5)
- [x] `npx eslint .` → clean
- [x] `SudokuTypeSelector.test.tsx` 6/6 pass
- [x] `GameProvider.test.tsx` 6/6 pass
- [x] Full unit suite still passes
- [ ] CI: new `typecheck` job runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)