### PR TITLE
perf(game): completion effect no longer re-runs on every timer tick

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -75,6 +75,15 @@ export function GameContainer() {
   // the updated value.
   const isNewBestTimeRef = useRef(false);
 
+  // Live mirror of state.elapsedTime so the completion effect can read the
+  // current value WITHOUT depending on state.elapsedTime — which would
+  // otherwise re-run the effect every second of play (60 wasted runs per
+  // minute, all of them no-ops outside the gameStatus transition we care
+  // about). Updated inline on every render so it's always fresh when the
+  // effect actually fires (on gameStatus change).
+  const elapsedTimeRef = useRef(state.elapsedTime);
+  elapsedTimeRef.current = state.elapsedTime;
+
   // Timer hook
   useTimer(state.gameStatus, actions.updateTime);
 
@@ -90,8 +99,10 @@ export function GameContainer() {
     const prevErrorsSize = prevErrorsSizeRef.current;
 
     if (state.gameStatus === GAME_STATUS.COMPLETED && prevStatus !== GAME_STATUS.COMPLETED) {
-      isNewBestTimeRef.current = updateBestTime(state.difficulty, state.elapsedTime);
-      recordGameComplete(state.sudokuType, state.difficulty, state.elapsedTime, state.mistakeCount);
+      // Use the ref instead of state.elapsedTime so this effect doesn't
+      // depend on the timer tick (see #143).
+      isNewBestTimeRef.current = updateBestTime(state.difficulty, elapsedTimeRef.current);
+      recordGameComplete(state.sudokuType, state.difficulty, elapsedTimeRef.current, state.mistakeCount);
       if (isPlayingDailyRef.current && playingDailyDateRef.current) {
         markDailyCompleted(playingDailyDateRef.current);
         isPlayingDailyRef.current = false;
@@ -115,10 +126,12 @@ export function GameContainer() {
 
     prevGameStatusRef.current = state.gameStatus;
     prevErrorsSizeRef.current = state.errors.size;
+    // state.elapsedTime intentionally NOT in deps — read via elapsedTimeRef
+    // so the effect doesn't fire on every timer tick (#143).
     // dailyInfo.date intentionally NOT in deps — completion uses the captured
     // playingDailyDateRef so midnight refresh of dailyInfo doesn't change which
     // day gets credited.
-  }, [state.errors, state.gameStatus, state.elapsedTime, state.difficulty, state.sudokuType, state.mistakeCount, markDailyCompleted, playVictorySound, playErrorSound, playDigitSound, vibrateComplete, vibrateError, vibrateDigit]);
+  }, [state.errors, state.gameStatus, state.difficulty, state.sudokuType, state.mistakeCount, markDailyCompleted, playVictorySound, playErrorSound, playDigitSound, vibrateComplete, vibrateError, vibrateDigit]);
 
   // Confetti on completion — declared AFTER the sound effect so React runs it
   // second, giving the sound effect a chance to update isNewBestTimeRef first.


### PR DESCRIPTION
## Summary

- **Closes #143** — completion-detection effect no longer re-runs every second of play
- Replaces `state.elapsedTime` dep with an inline-synced `elapsedTimeRef`
- Effect cadence drops from 60/min during play to "only when something meaningful changes" (digit input, completion, difficulty/type swap)

## How it works

The completion effect needs `elapsedTime` only when `gameStatus` transitions to `COMPLETED` — to pass the final time into `updateBestTime` and `recordGameComplete`. But having `state.elapsedTime` in the dep array meant the effect re-ran every time the timer ticked, which is once per second of play.

Fix: mirror `state.elapsedTime` into a `useRef` updated inline on every render:

```tsx
const elapsedTimeRef = useRef(state.elapsedTime);
elapsedTimeRef.current = state.elapsedTime;
```

Refs are exempt from React's `exhaustive-deps` rule. Reading `elapsedTimeRef.current` inside the effect doesn't add a dep, but the inline assignment guarantees the ref is fresh whenever the effect actually fires.

## Why not `useEffectEvent`?

That's the React-team-blessed primitive for this exact scenario, but it's still in RFC and not stable. The ref-mirror pattern is the established workaround used throughout the React docs.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean (no `react-hooks/exhaustive-deps` warnings)
- [x] Full unit suite passes
- [ ] Manual: complete a puzzle, verify the completion sound + haptic + best-time + stats record fire correctly with the right `elapsedTime`

## Why no automated regression test?

Effect re-run frequency is an implementation detail. A test that asserts "the effect runs N times" would be brittle against React internals. The behavioral surface (completion correctly records the right `elapsedTime`) is already covered by existing best-time and stats tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)