### PR TITLE
chore: add Dependabot config for npm + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration — keeps npm + GitHub Actions deps current.
+# Closes issue #121.
+#
+# Why this config:
+# - npm: weekly schedule keeps cadence predictable. Minor + patch bumps
+#   are grouped into one PR per week so we don't get N PRs for N
+#   incremental version bumps. Major bumps stay separate (they need
+#   attention anyway — breaking changes, deprecations, etc.).
+# - github-actions: weekly. Pairs with the planned SHA-pinning of
+#   anthropics/claude-code-action (#120) — once SHA-pinned, this rule
+#   keeps it fresh automatically.
+# - open-pull-requests-limit caps noise; tune later if it bites.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- **Closes #121** — adds `.github/dependabot.yml`
- Weekly npm updates with minor+patch grouped into one PR (major bumps stay separate)
- Weekly github-actions updates — sets up the auto-maintain story for the SHA-pinned `anthropics/claude-code-action` (planned in #120)

## Why now

Today's `npm audit` is clean (0 vulns / 5 prod deps), but that's a snapshot. Without this config:
- A CVE in react/vite/i18next doesn't trigger any local signal
- GitHub Pages keeps serving the vulnerable bundle until someone manually re-audits

With Dependabot: PR within ~24h of upstream release/advisory. Solo-dev maintenance windfall.

## Config notes

- **`open-pull-requests-limit: 5`** for npm, **3** for actions — caps noise; tune if it bites
- **Grouping**: only minor+patch grouped (majors get their own PR for review attention)
- **No `versioning-strategy`** override — Dependabot defaults to "increase" which respects your existing semver caret pinning in package.json

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` → valid)
- [ ] After merge: first Dependabot PR appears within 24-48h (will be a no-op if everything is current; the "no updates needed" status is itself signal that it's wired correctly)

## Follow-ups

- #120 (SHA-pin third-party action) becomes more impactful once Dependabot can auto-bump the SHA
- #119 (.env gitignore) — independent, separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)