### PR TITLE
security: SHA-pin anthropics/claude-code-action

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,7 +26,11 @@ jobs:
         fetch-depth: 0
 
     - name: Run Claude Code Review
-      uses: anthropics/claude-code-action@v1
+      # SHA-pinned (was @v1) — protects CLAUDE_CODE_OAUTH_TOKEN from a
+      # supply-chain attack on this third-party action. Dependabot's
+      # github-actions ecosystem rule will propose SHA bumps as new tags
+      # land. See #120 for context.
+      uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434  # v1
       with:
         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         prompt: |


### PR DESCRIPTION
## Summary

- **Closes #120** — pins `anthropics/claude-code-action@v1` to commit SHA `567fe954…`
- No behavior change — `567fe95` is what `v1` is currently pointing to (verified via GitHub API)
- Pairs with #152 (Dependabot) — SHA bumps now arrive as reviewable PRs instead of an opaque tag move

## Why

`@v1` is a floating tag. If `anthropics/claude-code-action` is ever compromised, the next PR run fetches malicious code with `CLAUDE_CODE_OAUTH_TOKEN` + PR-write + issues-write + id-token-write permissions.

Mitigating factor (already in place): the workflow's `if: github.event.pull_request.user.login == 'LeoMo42'` gate closes the forked-PR vector. The remaining risk is purely upstream supply chain — solved by pinning.

## How update flow works now

1. Anthropic ships a new release → Dependabot opens a PR with the SHA diff
2. PR description shows "v1.x.y → v1.x.z" with the actual commit message
3. Reviewer can read what's changing instead of trusting an opaque tag move
4. Merge → SHA pin updated, CI continues to be reproducible

## What's NOT in this PR

First-party actions (`actions/checkout`, `actions/setup-node`, etc.) are still at floating tags. Two reasons:
1. They're GitHub-maintained — supply-chain risk is structurally lower
2. Dependabot's first run will SHA-pin them automatically — no manual work needed

## Test plan

- [x] YAML validates
- [x] Comment + SHA + version annotation in the workflow file makes the change auditable
- [ ] Next PR's Claude review action runs successfully against the pinned SHA (this PR will exercise it!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)