### PR TITLE
security: gitignore .env / .env.* (allow .env.example)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ dist
 dist-ssr
 *.local
 
+# Env files — never track. .env.example IS allowed (template for new
+# developers / docs). Without these rules, the moment someone adds .env
+# with VITE_ANALYTICS_KEY / VITE_SENTRY_DSN / dev API tokens it leaks
+# to the public repo on the next `git add`.
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## Summary

- **Closes #119** — preventive fix: `.env` and `.env.*` are now ignored, with `.env.example` explicitly re-included for templates/docs

## Why

Today no `.env` exists. The fix is for the future: the moment someone adds one with a real key, it would leak to the public repo on the next `git add`. `VITE_*` vars are client-public-by-design, but non-`VITE_*` build-time tokens or future-backend secrets would leak as bonafide secrets.

## Behavior

| File | Ignored? | Why |
|---|---|---|
| `.env` | ✅ | line 19 |
| `.env.local` | ✅ | line 20 (`.env.*` glob) |
| `.env.production` | ✅ | line 20 |
| `.env.example` | ❌ | line 21 (`!.env.example` negation) |

Verified with `git check-ignore -v` for each pattern.

## Closes the security trio

After this lands, all 3 issues from `/cso daily` are addressed:
- #121 ✅ Dependabot config
- #120 ✅ SHA-pin claude-code-action
- #119 ✅ .env gitignore (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)