### PR TITLE
chore: knip cleanup — drop unused exports + fix config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,8 @@
 {
-  "ignore": [".claude/**", "e2e/**"],
+  "entry": [
+    "vitest.unit.config.ts"
+  ],
   "ignoreDependencies": [
-    "@testing-library/react",
     "@testing-library/user-event"
   ],
   "ignoreBinaries": ["shellcheck"]

--- a/src/hooks/useDaily.ts
+++ b/src/hooks/useDaily.ts
@@ -7,7 +7,7 @@ import {
 } from '../utils/dailyPuzzle';
 import type { DailyInfo } from '../utils/dailyPuzzle';
 
-export interface UseDailyReturn {
+interface UseDailyReturn {
   dailyInfo: DailyInfo;
   isCompleted: boolean;
   streak: { current: number; best: number };

--- a/src/utils/dailyPuzzle.ts
+++ b/src/utils/dailyPuzzle.ts
@@ -44,7 +44,7 @@ export interface DailyInfo {
   difficulty: DifficultyLevel;
 }
 
-export interface DailyStore {
+interface DailyStore {
   version: number;
   currentStreak: number;
   bestStreak: number;

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -17,7 +17,7 @@ export function buildShareUrl(
   return `${baseUrl}?type=${encodeURIComponent(type)}&difficulty=${encodeURIComponent(difficulty)}`;
 }
 
-export type ShareOutcome = 'shared' | 'copied' | 'cancelled' | 'failed';
+type ShareOutcome = 'shared' | 'copied' | 'cancelled' | 'failed';
 
 /**
  * Tries navigator.share first; falls back to navigator.clipboard.writeText.

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -41,7 +41,7 @@ export function loadStats(): StatsStore {
   }
 }
 
-export function saveStats(store: StatsStore): void {
+function saveStats(store: StatsStore): void {
   try {
     localStorage.setItem(STATS_KEY, JSON.stringify(store));
   } catch { /* private browsing or quota */ }


### PR DESCRIPTION
## Summary

- **Closes #115** — `npx knip` now exits clean (zero findings, zero hints)
- 4 unused `export` keywords dropped (the symbols themselves stay — they're used internally; the exports were dead)
- `knip.json` simplified: false-positive fix for `vitest.unit.config.ts`, redundant ignores removed, `@testing-library/react` un-ignored

## Symbol changes

| File:line | Before | After | Why safe |
|---|---|---|---|
| `stats.ts:44` | `export function saveStats` | `function saveStats` | Used by `recordGameStart` in same file |
| `share.ts:20` | `export type ShareOutcome` | `type ShareOutcome` | Return type of `shareOrCopy` in same file (TS infers for callers) |
| `dailyPuzzle.ts:47` | `export interface DailyStore` | `interface DailyStore` | Return type of `loadDailyStore`/`recordDailyCompletion` (TS infers) |
| `useDaily.ts:10` | `export interface UseDailyReturn` | `interface UseDailyReturn` | Return type of `useDaily` (TS infers) |

Verified zero external imports of any of the 4 via grep before unexporting.

## Config changes

```diff
 {
+  "entry": ["vitest.unit.config.ts"],
-  "ignore": [".claude/**", "e2e/**"],
   "ignoreDependencies": [
-    "@testing-library/react",
     "@testing-library/user-event"
   ],
   "ignoreBinaries": ["shellcheck"]
 }
```

- `vitest.unit.config.ts` is referenced via `--config` CLI flag, not import — knip needs `entry` to recognize it
- `.claude/**` and `e2e/**` ignores were redundant (gitignore + auto-detect handle them)
- `@testing-library/react` is used in 5+ test files (no longer needs ignore)
- `@testing-library/user-event` actually unused, but uninstalling is a separate change

## Test plan

- [x] `npx knip` → exit 0, zero output
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx eslint .` → clean
- [x] Full unit suite passes
- [ ] Optional follow-up: gate knip in CI to prevent regression (`npx knip --no-progress` as a new job)

## Closes the /health audit
With this PR, all 4 issues from the original `/health` audit are addressed:
- #114 ✅ (typecheck) — closed by #150
- #115 ✅ (knip) — this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)