### PR TITLE
fix(game): confirm before discarding mid-game progress on New Game

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -287,12 +287,17 @@ export function GameContainer() {
   }, [state.selectedCell, state.gameStatus, actions, currentMistakeLimit]);
 
   const handleNewGame = useCallback(() => {
+    if (
+      (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) &&
+      state.historyIndex > 0 &&
+      !window.confirm(t('game.confirmNewGame'))
+    ) return;
     isPlayingDailyRef.current = false;
     playingDailyDateRef.current = null;
     setIsPlayingDaily(false);
     actions.newGame(state.difficulty, state.sudokuType);
     recordGameStart(state.sudokuType, state.difficulty);
-  }, [state.difficulty, state.sudokuType, actions]);
+  }, [state.difficulty, state.sudokuType, state.gameStatus, state.historyIndex, actions, t]);
 
   const handleStartDaily = useCallback(() => {
     if (


### PR DESCRIPTION
## Summary

- **Closes #133** — `New Game` button now respects the same confirm-before-discard guard as the other three newGame() entry points
- Closes the consistency gap from #149's broader cleanup

## Before / After

Before: `New Game` silently replaced the in-progress puzzle.
After: confirm dialog `game.confirmNewGame` fires when there's progress to lose.

## All four guards now match

```ts
if ((PLAYING || PAUSED) && historyIndex > 0 && !confirm(t('game.confirmNewGame'))) return;
```

| Callback | Confirm guard | Notes |
|---|---|---|
| `handleStartDaily` | ✅ | Added in #149 |
| `handleDifficultyChange` | ✅ | Added in #105, PAUSED extended in #149 |
| `handleTypeChange` | ✅ | Added in #105, PAUSED extended in #149 |
| `handleNewGame` | ✅ **this PR** | — |

## Test plan

- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx eslint .` → clean
- [x] Full unit suite passes
- [ ] Manual: start a puzzle, make a move, click "New Game" → confirm fires
- [ ] Manual: complete a puzzle, click "New Game" → no confirm (already-finalized state)
- [ ] Manual: pause mid-game, click "New Game" → confirm fires

## Why no automated test

Same reasoning as #149 — GameContainer has no component-level test harness; standing one up for a 5-line consistency fix is disproportionate. The pattern is mechanical and the manual repro is straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)