### PR TITLE
a11y(streak): aria-hidden on countdown span

### DIFF
--- a/src/components/UI/StreakBanner.tsx
+++ b/src/components/UI/StreakBanner.tsx
@@ -66,7 +66,17 @@ export function StreakBanner({ dailyInfo, isCompleted, isPlayingDaily, streak, o
               {t('daily.completed')}
             </span>
           </div>
-          <span className="text-xs text-gray-500 dark:text-gray-400 tabular-nums font-mono whitespace-nowrap flex-shrink-0">
+          {/*
+            aria-hidden so screen readers don't re-announce the countdown
+            on every 1Hz tick (#141). The countdown is decorative — the
+            surrounding "Completed ✓" text already conveys the load-bearing
+            information ("you're done for today, come back tomorrow"). SR
+            users don't need second-level precision on when to come back.
+          */}
+          <span
+            aria-hidden="true"
+            className="text-xs text-gray-500 dark:text-gray-400 tabular-nums font-mono whitespace-nowrap flex-shrink-0"
+          >
             {t('daily.nextIn', { time: countdown })}
           </span>
         </div>


### PR DESCRIPTION
## Summary

- **Closes #141** — `aria-hidden="true"` on the countdown span so screen readers don't re-announce `HH:MM:SS` on every 1Hz tick

## Why

The countdown updates once per second. Without `aria-hidden`, screen readers that poll the DOM (some VoiceOver / NVDA configs) would announce the new time every tick → noise.

## Why hide instead of expose coarsely

The countdown is decorative. The surrounding banner already says "Completed ✓" — that's the actionable information for an SR user. Second-level precision on "when can I play again" doesn't help; "tomorrow" is implicit from the completed state.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] StreakBanner tests pass (8/8)
- [ ] Manual VoiceOver: complete the daily, verify the banner reads "Day #N · 🔥 N day streak · Completed" without the time being announced or repeated

🤖 Generated with [Claude Code](https://claude.com/claude-code)