### PR TITLE
a11y(streak): decompose play-state banner so only the CTA is a button

### DIFF
--- a/src/components/UI/StreakBanner.tsx
+++ b/src/components/UI/StreakBanner.tsx
@@ -81,25 +81,34 @@ export function StreakBanner({ dailyInfo, isCompleted, isPlayingDaily, streak, o
           </span>
         </div>
       ) : (
-        <button
-          onClick={onPlay}
-          disabled={isPlayingDaily}
-          data-testid="streak-banner-play"
-          className="w-full flex items-center justify-between gap-4 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-xl px-4 py-3 hover:bg-indigo-100 dark:hover:bg-indigo-900/40 transition-colors disabled:cursor-default group"
-        >
+        // Decomposed (#132): the row is a plain div, only the CTA is a
+        // button. Previously the entire row was one <button>, which made
+        // its accessible name the concatenated "#N · streak text · Play
+        // today" — confusing for screen-reader users and ambiguous for
+        // keyboard users about what activation actually does. Now SR
+        // users hear the day/streak as plain text, then a separate
+        // "Play today" button.
+        <div className="flex items-center justify-between gap-4 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-xl px-4 py-3">
           <div className="flex items-center gap-3 min-w-0">
             <span className="text-sm font-semibold text-indigo-700 dark:text-indigo-400 whitespace-nowrap">
               {dayLabel}
             </span>
-            <span className="hidden sm:inline text-gray-300 dark:text-gray-600">·</span>
+            <span aria-hidden="true" className="hidden sm:inline text-gray-300 dark:text-gray-600">·</span>
             <span className="hidden sm:inline text-sm font-medium text-orange-500 dark:text-orange-400 whitespace-nowrap">
               {streakNode}
             </span>
           </div>
-          <span className="text-sm font-semibold text-indigo-600 dark:text-indigo-400 whitespace-nowrap flex-shrink-0 group-hover:translate-x-0.5 group-disabled:translate-x-0 transition-transform">
-            {isPlayingDaily ? t('daily.playing') : t('daily.playCta')}
-          </span>
-        </button>
+          <button
+            onClick={onPlay}
+            disabled={isPlayingDaily}
+            data-testid="streak-banner-play"
+            className="group text-sm font-semibold text-indigo-600 dark:text-indigo-400 whitespace-nowrap flex-shrink-0 px-2 py-1 -mr-2 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-900/40 disabled:cursor-default disabled:hover:bg-transparent transition-colors"
+          >
+            <span className="inline-block group-hover:translate-x-0.5 group-disabled:translate-x-0 transition-transform">
+              {isPlayingDaily ? t('daily.playing') : t('daily.playCta')}
+            </span>
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Closes #132** — splits the play-state streak banner so the day/streak text is plain markup and only the "Play today" CTA is a button
- Cleans up a11y semantics; existing test surface preserved (8/8 pass)
- Bonus: `aria-hidden` on the `·` separator (decorative)

## Before

```html
<button>  ← whole row was one button
  <span>Day #N</span>
  <span>·</span>
  <span>🔥 5 day streak</span>
  <span>Play today →</span>
</button>
```

Accessible name = concatenation of all text. SR reads "button: number 9611 dot Start your streak Play today". Confusing.

## After

```html
<div>
  <div>                           ← informational
    <span>Day #N</span>
    <span aria-hidden>·</span>
    <span>🔥 5 day streak</span>
  </div>
  <button>                        ← isolated CTA
    Play today →
  </button>
</div>
```

SR reads "Day N, streak 5", then "Play today, button". Clean.

## Trade-off (intentional)

Lost: click-anywhere-on-row affordance. Now only the button is clickable (with a hover halo for visual focus).

Why accept: per #132's spec, explicit-CTA semantics > whole-row click area. The click area is still generous (the button itself + its hover-halo padding). If engagement data later shows the broader click was load-bearing, we can revisit by adding `onClick` delegation on the outer div (without making it a button — preserving semantics).

## What did NOT change

- `isCompleted` branch (the green "Completed ✓" banner) — already had clean structure (no wrapping button)
- `data-testid="streak-banner-play"` — preserved on the new isolated button
- Visual styling — colors, spacing, hover transitions all preserved

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] StreakBanner tests pass 8/8
- [ ] Manual VoiceOver: tab to banner → hear "Day N, streak 5" as text, then "Play today" as a button (not concatenated)
- [ ] Manual visual: hover/click "Play today" works the same; clicking on "#N" or the streak text now does NOT trigger play (the desired new behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)