### PR TITLE
fix(stories): use canonical types + correct dayNumber in StreakBanner mock

### DIFF
--- a/src/components/UI/StreakBanner.stories.tsx
+++ b/src/components/UI/StreakBanner.stories.tsx
@@ -1,11 +1,17 @@
+import type { DailyInfo } from '../../utils/dailyPuzzle';
 import { StreakBanner } from './StreakBanner';
 
-const dailyInfo = {
-  dayNumber: 42,
+// dayNumber matches the date string: Apr 13, 2026 = 9599 days since
+// 2000-01-01 UTC (toDayNumber convention from dailyPuzzle.ts). Type and
+// difficulty use the canonical uppercase enum values from src/types/index.ts
+// — the previous mock used 'classic'/'easy' which compiled via `as const`
+// but didn't match any real SudokuTypeId/DifficultyLevel value.
+const dailyInfo: DailyInfo = {
+  dayNumber: 9599,
   date: '2026-04-13',
   seed: 12345,
-  type: 'classic' as const,
-  difficulty: 'easy' as const,
+  type: 'CLASSIC',
+  difficulty: 'EASY',
 };
 
 export default {


### PR DESCRIPTION
## Summary

- **Closes #140** — fixes type and value mismatches in the StreakBanner storybook mock
- Adds explicit `: DailyInfo` annotation so future drift is caught at type-check time

## Changes

| Field | Before | After | Why |
|---|---|---|---|
| `type` | `'classic' as const` | `'CLASSIC'` | Real `SudokuTypeId` is uppercase |
| `difficulty` | `'easy' as const` | `'EASY'` | Real `DifficultyLevel` is uppercase |
| `dayNumber` | `42` | `9599` | Matches `date: '2026-04-13'` per `toDayNumber` (Date.UTC verified) |
| (annotation) | implicit shape | `: DailyInfo` | Type-check catches future drift |

## Why it matters

Storybook is a documentation surface for the component. A mock that doesn't reflect real production data ("`'classic'`" never appears anywhere else in the app, dayNumber 42 can never co-exist with that date) is misleading documentation. With this PR the mock is type-checked against `DailyInfo` directly.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] 5 stories preserved (PlayCta, Playing, NoStreak, Completed, CompletedNoStreak)
- [ ] Manual: `npm run storybook` → all 5 stories render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)