### PR TITLE
perf(streak): pause countdown interval when tab is hidden

### DIFF
--- a/src/components/UI/StreakBanner.test.tsx
+++ b/src/components/UI/StreakBanner.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import type { SudokuTypeId, DifficultyLevel } from '../../types/index';
 import { StreakBanner } from './StreakBanner';
 
@@ -139,5 +139,73 @@ describe('StreakBanner — completed', () => {
       />
     );
     expect(onPlay).not.toHaveBeenCalled();
+  });
+});
+
+describe('StreakBanner — countdown visibility gating (#139)', () => {
+  // Helper: set document.visibilityState and dispatch the visibilitychange
+  // event the way browsers do. configurable=true is REQUIRED so successive
+  // tests can re-define it.
+  const setVisibility = (state: 'visible' | 'hidden') => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  };
+
+  // Reset to visible after each test so other tests aren't poisoned.
+  afterEach(() => {
+    setVisibility('visible');
+  });
+
+  it('does not advance the countdown while the tab is hidden', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 23, 30, 0));
+    render(
+      <StreakBanner
+        dailyInfo={dailyInfo}
+        isCompleted={true}
+        isPlayingDaily={false}
+        streak={streak}
+        onPlay={onPlay}
+      />
+    );
+    const before = screen.getByText(/daily\.nextIn/).textContent;
+
+    act(() => {
+      setVisibility('hidden');
+      vi.advanceTimersByTime(5_000);
+    });
+
+    // Same text — interval was paused, no setCountdown was fired.
+    expect(screen.getByText(/daily\.nextIn/).textContent).toBe(before);
+  });
+
+  it('resumes the countdown when the tab becomes visible again', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 23, 30, 0));
+    render(
+      <StreakBanner
+        dailyInfo={dailyInfo}
+        isCompleted={true}
+        isPlayingDaily={false}
+        streak={streak}
+        onPlay={onPlay}
+      />
+    );
+    const initial = screen.getByText(/daily\.nextIn/).textContent;
+
+    // Hide → wait → show. The countdown should reflect elapsed time
+    // immediately on focus (synchronous tick in start()), without
+    // having ticked while hidden.
+    act(() => {
+      setVisibility('hidden');
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.getByText(/daily\.nextIn/).textContent).toBe(initial);
+
+    act(() => {
+      setVisibility('visible');
+    });
+    expect(screen.getByText(/daily\.nextIn/).textContent).not.toBe(initial);
   });
 });

--- a/src/components/UI/StreakBanner.tsx
+++ b/src/components/UI/StreakBanner.tsx
@@ -36,12 +36,34 @@ export function StreakBanner({ dailyInfo, isCompleted, isPlayingDaily, streak, o
 
   useEffect(() => {
     if (!isCompleted) return;
-    // Synchronous first tick so the initial paint after isCompleted flips
-    // true shows a real countdown, not the empty-string seed.
     const tick = () => setCountdown(timeUntilMidnight());
-    tick();
-    const id = setInterval(tick, 1_000);
-    return () => clearInterval(id);
+    let id: number | undefined;
+
+    // Visibility-gated interval (#139): pause the 1Hz tick when the
+    // tab is backgrounded. The countdown is decorative when nobody's
+    // watching — no point spending wakeups on it. Resume on focus
+    // with a synchronous tick so the visible value is fresh, not
+    // however-many-seconds-old.
+    const start = () => {
+      tick();
+      id = window.setInterval(tick, 1_000);
+    };
+    const stop = () => {
+      if (id !== undefined) {
+        window.clearInterval(id);
+        id = undefined;
+      }
+    };
+    const onVisibilityChange = () => {
+      document.visibilityState === 'visible' ? start() : stop();
+    };
+
+    if (document.visibilityState === 'visible') start();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   }, [isCompleted]);
 
   const dayLabel = t('daily.day', { number: dailyInfo.dayNumber });


### PR DESCRIPTION
## Summary

- **Closes #139** — the completion-state countdown's 1Hz `setInterval` now pauses when the tab is hidden and resumes (with a synchronous tick) when it's visible again
- 2 new regression tests in `StreakBanner.test.tsx` (10/10 pass)

## Background

#139 had two concerns:

| Part | What | Status |
|---|---|---|
| **B** | "Countdown stuck at 00:00:00, banner doesn't auto-flip" | Already fixed by #148 (midnight refresh in `useDaily` flips `isCompleted` to false for the new day → banner switches branches) |
| **A** | "1Hz interval ticks forever on backgrounded tabs, no visibility gating" | This PR |

Worst case before: user has the daily completed, leaves tab open in the background, the interval keeps firing once per second forever — a real battery cost on mobile, even if the per-tick work is tiny.

## How

- On `visibilitychange → hidden`: `clearInterval`, drop the handle
- On `visibilitychange → visible`: synchronous `tick()` (so the visible value is current, not stale) + restart interval
- Cleanup on unmount handles both the interval and the listener

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] StreakBanner tests pass 10/10 (8 existing + 2 new)
- [ ] Manual: complete the daily, switch to another tab, leave for an hour, switch back → countdown is fresh (not 60 minutes stale or stuck) and timer resumes

## Why a synchronous tick on resume?

Without it the user briefly sees the stale value (last update before hiding) for up to 1s after refocusing — looks broken. The synchronous tick guarantees the displayed value reflects the clock immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)