### PR TITLE
fix(layout): split action row into primary + transient groups

### DIFF
--- a/src/components/Controls/GameControls.tsx
+++ b/src/components/Controls/GameControls.tsx
@@ -48,6 +48,16 @@ export function GameControls({
 
   return (
     <div className="flex flex-col gap-3">
+      {/*
+        Two rows split by intent so the layout stays stable across
+        locales (#131). When everything was a single flex-wrap row,
+        Russian text widths pushed Undo to row 2 while English kept it
+        on row 1 — muscle memory broke whenever the user switched
+        language.
+
+        Row 1 — primary actions (start / inspect / mark)
+        Row 2 — transient controls (history + pause/resume timer)
+      */}
       <div className="flex gap-2 flex-wrap">
         <Button onClick={onNewGame} variant="primary" data-testid="new-game-button">
           {t('game.newGame')}
@@ -73,29 +83,35 @@ export function GameControls({
             >
               {notesMode ? '✓ ' : ''}{t('game.notes')}
             </Button>
-
-            <Button onClick={onUndo} variant="secondary" disabled={!canUndo}>
-              {t('game.undo')}
-            </Button>
-
-            <Button onClick={onRedo} variant="secondary" disabled={!canRedo}>
-              {t('game.redo')}
-            </Button>
           </>
         )}
-
-        {isPlaying && (
-          <Button onClick={onPause} variant="secondary">
-            {t('game.pause')}
-          </Button>
-        )}
-
-        {isPaused && (
-          <Button onClick={onResume} variant="success">
-            {t('game.resume')}
-          </Button>
-        )}
       </div>
+
+      {(isPlaying || isPaused) && (
+        <div className="flex gap-2 flex-wrap">
+          {isPlaying && (
+            <>
+              <Button onClick={onUndo} variant="secondary" disabled={!canUndo}>
+                {t('game.undo')}
+              </Button>
+
+              <Button onClick={onRedo} variant="secondary" disabled={!canRedo}>
+                {t('game.redo')}
+              </Button>
+
+              <Button onClick={onPause} variant="secondary">
+                {t('game.pause')}
+              </Button>
+            </>
+          )}
+
+          {isPaused && (
+            <Button onClick={onResume} variant="success">
+              {t('game.resume')}
+            </Button>
+          )}
+        </div>
+      )}
 
       {isCompleted && (
         <div className="bg-green-100 dark:bg-green-900/40 border-2 border-green-600 dark:border-green-500 rounded-lg p-4 text-center flex flex-col items-center gap-3">


### PR DESCRIPTION
## Summary

- **Closes #131** — splits the action button row by semantic intent so the wrap point doesn't shift between locales

## Problem

Single flex-wrap row meant the wrap point was content-width-dependent:
- **EN (1280px right column):** `[New Game] [Check] [Hint] [Notes] [Undo]` / `[Redo] [Pause]` — Undo on row 1
- **RU (same viewport):** `[Новая игра] [Проверить] [Подсказка] [Заметки]` / `[Отменить] [Повторить] [Пауза]` — Undo on row 2

Switching language mid-session moved Undo to a different row → muscle memory broken.

## Fix

Split into two structural rows:

```html
<div class="flex flex-col gap-3">
  <div class="flex gap-2 flex-wrap">  <!-- primary -->
    [New Game] [Check] [Hint] [Notes]
  </div>
  <div class="flex gap-2 flex-wrap">  <!-- transient -->
    [Undo] [Redo] [Pause]
  </div>
</div>
```

Undo / Redo / Pause are ALWAYS together on the transient row regardless of how the primary group wraps. The primary group can still wrap internally on narrow viewports / long text — that's fine, just no longer leaks Undo across the boundary.

## Logical grouping

| Group | Buttons | Mental model |
|---|---|---|
| Primary | New Game, Check, Hint, Notes | "things I do TO the puzzle" |
| Transient | Undo, Redo, Pause/Resume | "things that affect HOW I'm playing" |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] Visual check in RU at 1280px: transient group stays on its own row even when primary wraps
- [x] `data-testid="new-game-button"` preserved (e2e smoke test)
- [ ] Manual check in EN: primary fits in one row, transient on its own row
- [ ] Manual mobile (375px): both groups wrap internally, but stay separated

🤖 Generated with [Claude Code](https://claude.com/claude-code)