### PR TITLE
fix(daily): sync streak across tabs via storage event

### DIFF
--- a/src/hooks/useDaily.test.ts
+++ b/src/hooks/useDaily.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useDaily } from './useDaily';
-import { recordDailyCompletion } from '../utils/dailyPuzzle';
-
-const DAILY_STORAGE_KEY = 'sudoku-daily';
+import { recordDailyCompletion, DAILY_STORAGE_KEY } from '../utils/dailyPuzzle';
 
 beforeEach(() => {
   localStorage.clear();
@@ -194,6 +192,68 @@ describe('useDaily — markCompleted', () => {
     // The crucial UX assertion: TODAY's daily (Jun 16) is NOT marked
     // completed — the user can still start it. isCompleted is queried
     // against the current dailyInfo, which has rolled over to Jun 16.
+    expect(result.current.isCompleted).toBe(false);
+  });
+});
+
+describe('useDaily — cross-tab sync (#135)', () => {
+  // The `storage` event fires in OTHER tabs when localStorage changes.
+  // jsdom doesn't auto-fire it, so we dispatch StorageEvent manually to
+  // simulate what a real browser would emit cross-tab.
+
+  it('syncs isCompleted when another tab records today\'s completion', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.isCompleted).toBe(false);
+
+    act(() => {
+      // "Another tab" writes the completion to localStorage.
+      recordDailyCompletion(new Date(2024, 5, 15));
+      // Browsers emit `storage` on the OTHER tab; we simulate that here.
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: DAILY_STORAGE_KEY,
+        newValue: localStorage.getItem(DAILY_STORAGE_KEY),
+      }));
+    });
+
+    expect(result.current.isCompleted).toBe(true);
+  });
+
+  it('syncs streak count when another tab updates the store', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.streak.current).toBe(0);
+
+    act(() => {
+      recordDailyCompletion(new Date(2024, 5, 14));
+      recordDailyCompletion(new Date(2024, 5, 15));
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: DAILY_STORAGE_KEY,
+        newValue: localStorage.getItem(DAILY_STORAGE_KEY),
+      }));
+    });
+
+    expect(result.current.streak.current).toBe(2);
+  });
+
+  it('ignores storage events for unrelated keys', () => {
+    vi.setSystemTime(new Date(2024, 5, 15, 12, 0, 0));
+    const { result } = renderHook(() => useDaily());
+    expect(result.current.isCompleted).toBe(false);
+
+    act(() => {
+      // localStorage is updated…
+      recordDailyCompletion(new Date(2024, 5, 15));
+      // …but the storage event is for a DIFFERENT key (e.g. another
+      // unrelated app feature). Hook must not react.
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: 'sudoku-some-other-key',
+        newValue: 'whatever',
+      }));
+    });
+
+    // Hook state stays at its mount value — we filtered the event out
+    // and didn't recompute against the now-updated localStorage.
     expect(result.current.isCompleted).toBe(false);
   });
 });

--- a/src/hooks/useDaily.ts
+++ b/src/hooks/useDaily.ts
@@ -4,6 +4,7 @@ import {
   isDailyCompleted,
   recordDailyCompletion,
   getDailyStreak,
+  DAILY_STORAGE_KEY,
 } from '../utils/dailyPuzzle';
 import type { DailyInfo } from '../utils/dailyPuzzle';
 
@@ -70,9 +71,26 @@ export function useDaily(): UseDailyReturn {
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
+    // Cross-tab sync (#135): the `storage` event fires in OTHER tabs (not
+    // the writer) when localStorage changes. If another tab completed
+    // today's daily, this tab's in-memory `isCompleted` and `streak`
+    // would diverge from disk truth until reload — leading to stale
+    // banner state and the user re-clicking "Play today" on an
+    // already-done puzzle. Re-read both on every storage event for our
+    // key. We don't refresh dailyInfo from a storage event — dailyInfo
+    // is computed from `new Date()`, not localStorage, so it's already
+    // self-consistent across tabs.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== DAILY_STORAGE_KEY) return;
+      setIsCompleted(isDailyCompleted());
+      setStreak(getDailyStreak());
+    };
+    window.addEventListener('storage', onStorage);
+
     return () => {
       window.clearTimeout(timeoutId);
       document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('storage', onStorage);
     };
   }, [refreshIfDayChanged]);
 

--- a/src/utils/dailyPuzzle.ts
+++ b/src/utils/dailyPuzzle.ts
@@ -1,6 +1,8 @@
 import type { SudokuTypeId, DifficultyLevel } from '../types/index';
 
-const DAILY_STORAGE_KEY = 'sudoku-daily';
+// Exported so consumers (useDaily) can listen for cross-tab `storage`
+// events and filter by this exact key — avoids drift if we ever rename.
+export const DAILY_STORAGE_KEY = 'sudoku-daily';
 const DAILY_STORE_VERSION = 2;
 
 // Ordered list of variant types used in daily rotation.


### PR DESCRIPTION
## Summary

- **Closes #135** — `useDaily` now listens for cross-tab `storage` events and re-syncs `isCompleted` + `streak` when another tab updates the daily store
- 3 new regression tests
- Exports `DAILY_STORAGE_KEY` so consumers can filter storage events by exact key (no drift on rename)

## Failure mode (before)

1. Open the app in Tab A + Tab B
2. Tab A: complete the daily → localStorage written, Tab A state updated
3. Tab B: still shows "Play today" because React state hasn't seen the change
4. Tab B: click "Play today" → duplicate-game flow against an already-completed puzzle, in-memory state diverges from disk truth for the rest of the session

## Fix

```ts
const onStorage = (e: StorageEvent) => {
  if (e.key !== DAILY_STORAGE_KEY) return;
  setIsCompleted(isDailyCompleted());
  setStreak(getDailyStreak());
};
window.addEventListener('storage', onStorage);
```

The `storage` event fires in OTHER tabs (not the writer) when localStorage changes — exactly the cross-tab signal we need. We don't refresh `dailyInfo` from a storage event because `dailyInfo` is computed from `new Date()`, not localStorage — already self-consistent across tabs.

## Tests

3 new in `useDaily.test.ts`:

1. **syncs `isCompleted`** when another tab completes today's daily
2. **syncs streak count** when another tab builds a multi-day streak
3. **ignores unrelated storage keys** — only fires on `DAILY_STORAGE_KEY`

Tests dispatch `StorageEvent` manually because jsdom doesn't auto-fire them (and even real browsers don't fire `storage` in the same tab that wrote).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] 48/48 daily-related tests pass (32 dailyPuzzle + 16 useDaily)
- [ ] Manual: open the app in 2 tabs, complete the daily in Tab A, verify Tab B's banner switches to "Completed" without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)