### PR TITLE
ux: tighten Time/Mistakes card + relocate Settings drawer to header

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -440,6 +440,29 @@ export function GameContainer() {
               <span aria-hidden="true">📊</span>
             </button>
             <LanguageSwitcher />
+            {/*
+              Settings drawer moved here from the Time/Mistakes card (#128).
+              It used to sit inline next to the timer where it visually
+              implied "settings for the time"; in the header it joins the
+              other top-right utility buttons (stats, language) which is
+              the conventional location.
+            */}
+            <SettingsDrawer
+              highlightsEnabled={highlightsEnabled}
+              toggleHighlights={toggleHighlights}
+              soundEnabled={soundEnabled}
+              toggleSound={toggleSound}
+              celebrationEnabled={celebrationEnabled}
+              toggleCelebration={toggleCelebration}
+              hapticEnabled={hapticEnabled}
+              toggleHaptic={toggleHaptic}
+              isDark={isDark}
+              toggleTheme={toggleTheme}
+              colorBlindMode={colorBlindMode}
+              toggleColorBlindMode={toggleColorBlindMode}
+              onTour={openTour}
+              onPrint={() => window.print()}
+            />
           </div>
         </div>
 
@@ -555,29 +578,15 @@ export function GameContainer() {
               </div>
             </div>
 
-            {/* Timer and Game Controls - combined on mobile */}
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 sm:p-6">
-              <div className="flex items-center justify-between mb-4">
+            {/* Timer + mistake counter card. Padding tightened (#128)
+                from p-4/sm:p-6 to p-3/sm:p-4 — the previous card was
+                ~50% empty space because the two slim rows of content
+                didn't justify the inset. SettingsDrawer was here too,
+                moved to the top header next to language/stats. */}
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-3 sm:p-4">
+              <div className="flex items-center justify-between mb-3">
                 <span className="text-sm font-medium text-gray-600 dark:text-gray-400">{t('game.time')}</span>
-                <div className="flex items-center gap-2">
-                  <Timer elapsedTime={state.elapsedTime} />
-                  <SettingsDrawer
-                    highlightsEnabled={highlightsEnabled}
-                    toggleHighlights={toggleHighlights}
-                    soundEnabled={soundEnabled}
-                    toggleSound={toggleSound}
-                    celebrationEnabled={celebrationEnabled}
-                    toggleCelebration={toggleCelebration}
-                    hapticEnabled={hapticEnabled}
-                    toggleHaptic={toggleHaptic}
-                    isDark={isDark}
-                    toggleTheme={toggleTheme}
-                    colorBlindMode={colorBlindMode}
-                    toggleColorBlindMode={toggleColorBlindMode}
-                    onTour={openTour}
-                    onPrint={() => window.print()}
-                  />
-                </div>
+                <Timer elapsedTime={state.elapsedTime} />
               </div>
 
               {/* Mistake counter row: shows X N (or X N/M when limit on),


### PR DESCRIPTION
## Summary

- **Closes #128** — addresses both subproblems flagged in the original `/design-review`:
  1. The Time/Mistakes card was ~50% empty space (card padding outsized the content)
  2. The settings cog (⚙️) sat next to the timer, visually implying "settings for the time"

## Changes

| Concern | Before | After |
|---|---|---|
| Card padding | `p-4 sm:p-6` | `p-3 sm:p-4` |
| Time row bottom margin | `mb-4` | `mb-3` |
| Settings cog location | Inline next to `<Timer>` | Top-right header next to `📊 Stats` + `LanguageSwitcher` |

The cog move places it in the conventional "global utility" cluster (Stats / Language / Settings) where users already expect it. Removes the accidental "cog = timer settings" implication.

## Visual

After-shot ([attachment in PR if needed]):
- Top-right: 📊 Stats · 🇷🇺 RU · 🇬🇧 EN · ⚙️ Settings (was: 📊 · RU · EN, with cog in card)
- Right column: Number pad → Time/Mistakes (tighter) → Action buttons

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] Full unit suite passes
- [x] Visual confirmation: cog is in header, Time card is shorter
- [ ] Manual: open settings drawer from new location → verify all toggles still work (haptic, sound, theme, color-blind, etc.)
- [ ] Manual: SettingsDrawer's positioning (anchor / dropdown direction) still looks right in the new location

🤖 Generated with [Claude Code](https://claude.com/claude-code)