### PR TITLE
ux: tone down Type selector trigger to outlined card style

### DIFF
--- a/src/components/Controls/SudokuTypeSelector.tsx
+++ b/src/components/Controls/SudokuTypeSelector.tsx
@@ -118,13 +118,13 @@ export function SudokuTypeSelector({ currentType, onTypeChange, disabled }: Sudo
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-controls={listboxId}
-        className="w-full px-4 py-3 rounded-lg font-medium bg-purple-600 text-white text-left flex items-center justify-between disabled:opacity-50"
+        className="w-full px-4 py-3 rounded-lg font-medium bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 text-left flex items-center justify-between hover:border-gray-400 dark:hover:border-gray-500 transition-colors disabled:opacity-50"
       >
         <div>
           <div className="font-bold text-sm">
             {t(`sudokuTypes.${currentType}.name`)}
           </div>
-          <div className="text-xs opacity-90 mt-0.5">
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
             {t(`sudokuTypes.${currentType}.description`)}
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Closes #123** — Type dropdown trigger no longer dominates the right column with saturated purple
- Visual weight now matches Difficulty pills (peer-level controls behaving as peers)
- Side benefit: one fewer competing accent color, partial progress on #127 (color discipline)

## Before / After

| | Before | After |
|---|---|---|
| Background | `bg-purple-600` (saturated) | `bg-white dark:bg-gray-700` (neutral) |
| Border | none | `border border-gray-300/600` |
| Text | white on purple | `text-gray-900 dark:text-gray-100` |
| Subtitle | `opacity-90` over white | `text-gray-500 dark:text-gray-400` (proper grey hierarchy) |
| Hover | none | `hover:border-gray-400/500` (subtle) |

## Why outlined instead of matching Difficulty's blue

Type and Difficulty are different control kinds (13-variant dropdown vs 4-level pill row). The win is matching visual WEIGHT, not exact styling. Outlined form-control is the conventional dropdown-trigger look in 2026 web design and stays quiet in the layout.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] 6/6 SudokuTypeSelector tests pass
- [x] Visual screenshot: trigger is neutral, harmonizes with surrounding cards
- [ ] Manual: open dropdown — options list rendering still has purple highlight on currently-selected item (`bg-purple-50 text-purple-700`), unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)