### PR TITLE
feat(color): demote Clear-red and Streak-orange to align palette

### DIFF
--- a/src/components/Controls/NumberPad.tsx
+++ b/src/components/Controls/NumberPad.tsx
@@ -32,11 +32,13 @@ export function NumberPad({ onNumberClick, onClear, disabled }: NumberPadProps) 
         ))}
       </div>
 
-      {/* Clear button full width */}
+      {/* Clear button full width. variant=secondary (#127) — Clear is
+          reversible via Undo, not destructive. Reserve `danger` red for
+          irreversible actions (delete-stats, reset-game-permanently). */}
       <Button
         onClick={onClear}
         disabled={disabled}
-        variant="danger"
+        variant="secondary"
         className="w-full h-12"
       >
         {t('game.clear')}

--- a/src/components/Controls/NumberPad.tsx
+++ b/src/components/Controls/NumberPad.tsx
@@ -32,9 +32,7 @@ export function NumberPad({ onNumberClick, onClear, disabled }: NumberPadProps) 
         ))}
       </div>
 
-      {/* Clear button full width. variant=secondary (#127) — Clear is
-          reversible via Undo, not destructive. Reserve `danger` red for
-          irreversible actions (delete-stats, reset-game-permanently). */}
+      {/* Clear is reversible via Undo; reserve danger for permanent actions (#127) */}
       <Button
         onClick={onClear}
         disabled={disabled}

--- a/src/components/UI/StreakBanner.tsx
+++ b/src/components/UI/StreakBanner.tsx
@@ -83,7 +83,7 @@ export function StreakBanner({ dailyInfo, isCompleted, isPlayingDaily, streak, o
               {dayLabel}
             </span>
             <span className="hidden sm:inline text-gray-300 dark:text-gray-600">·</span>
-            <span className="hidden sm:inline text-sm font-medium text-orange-500 dark:text-orange-400 whitespace-nowrap">
+            <span className="hidden sm:inline text-sm font-medium text-indigo-600 dark:text-indigo-300 whitespace-nowrap">
               {streakNode}
             </span>
             <span className="hidden sm:inline text-gray-300 dark:text-gray-600">·</span>
@@ -119,7 +119,7 @@ export function StreakBanner({ dailyInfo, isCompleted, isPlayingDaily, streak, o
               {dayLabel}
             </span>
             <span aria-hidden="true" className="hidden sm:inline text-gray-300 dark:text-gray-600">·</span>
-            <span className="hidden sm:inline text-sm font-medium text-orange-500 dark:text-orange-400 whitespace-nowrap">
+            <span className="hidden sm:inline text-sm font-medium text-indigo-600 dark:text-indigo-300 whitespace-nowrap">
               {streakNode}
             </span>
           </div>


### PR DESCRIPTION
## Summary

- **Closes #127** — completes the color-discipline pass started in earlier PRs
- 2 changes: Clear button red → neutral, StreakBanner streak text orange → indigo
- Net result: palette goes from **5 competing accents** to **1 primary (blue) + 2 semantic (red/green)**

## Why these two

| | Before | After | Why |
|---|---|---|---|
| Clear button | `variant="danger"` (red) | `variant="secondary"` (neutral) | Clear is reversible via Undo. Reserve red for actually-destructive (Reset Stats stays red) |
| Streak text | `text-orange-500/400` | `text-indigo-600/300` | Banner is already indigo — orange streak text was fighting its own container. Now cohesive |

## Palette after this PR

| Role | Color | Used in |
|---|---|---|
| Primary | `blue-600` | New Game CTA, language toggle, Difficulty selected, StreakBanner border + text + CTA |
| Neutral | `gray-200/700` | All secondary buttons (incl. Clear), surfaces |
| Semantic-red | `red-600` | Error cells, ⚠️ mistake-limit warning, **Reset Stats** (only genuinely destructive button) |
| Semantic-green | `green-600` | Resume button, completion banner |
| Decorative | 🔥 emoji | Browser-rendered, not CSS — out of scope |

## What's NOT in this PR

- Wordmark redesign (#130) — typography landed in #179, custom logotype is separate
- Streak banner hero redesign (#124, #102) — depends on this color work, follow-up
- Color tokens / CSS custom properties — current values are hardcoded Tailwind. Extracting to a token system is a future PR if the project grows beyond a single app

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] Full unit suite passes
- [x] Visual screenshot: Clear is gray, page reads as more harmonious
- [ ] Manual: complete a streak of 5 → verify "🔥 5 days streak" text is indigo (not orange)
- [ ] Manual: Reset Stats button still appears red (semantic destructive — confirm it stays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)