### PR TITLE
feat(streak): hero treatment for the daily-puzzle banner

### DIFF
--- a/src/components/UI/StreakBanner.tsx
+++ b/src/components/UI/StreakBanner.tsx
@@ -106,20 +106,17 @@ export function StreakBanner({ dailyInfo, isCompleted, isPlayingDaily, streak, o
           </span>
         </div>
       ) : (
-        // Decomposed (#132): the row is a plain div, only the CTA is a
-        // button. Previously the entire row was one <button>, which made
-        // its accessible name the concatenated "#N · streak text · Play
-        // today" — confusing for screen-reader users and ambiguous for
-        // keyboard users about what activation actually does. Now SR
-        // users hear the day/streak as plain text, then a separate
-        // "Play today" button.
-        <div className="flex items-center justify-between gap-4 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-xl px-4 py-3">
-          <div className="flex items-center gap-3 min-w-0">
-            <span className="text-sm font-semibold text-indigo-700 dark:text-indigo-400 whitespace-nowrap">
-              {dayLabel}
+        // Hero treatment (#124). Was a thin notice-bar with everything in
+        // text-sm; now reads as a real CTA module. Two-line content (small
+        // label + big headline) on the left, filled primary button on the
+        // right. SR semantics preserved from #132 — the headline group is
+        // a plain <div>, only the CTA is a <button>.
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-xl px-4 py-4 sm:px-6 sm:py-5">
+          <div className="min-w-0 flex flex-col gap-0.5">
+            <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600/70 dark:text-indigo-400/70">
+              {t('daily.title')} <span className="font-mono">{dayLabel}</span>
             </span>
-            <span aria-hidden="true" className="hidden sm:inline text-gray-300 dark:text-gray-600">·</span>
-            <span className="hidden sm:inline text-sm font-medium text-indigo-600 dark:text-indigo-300 whitespace-nowrap">
+            <span className="text-lg sm:text-xl font-bold text-indigo-900 dark:text-indigo-100">
               {streakNode}
             </span>
           </div>
@@ -127,7 +124,7 @@ export function StreakBanner({ dailyInfo, isCompleted, isPlayingDaily, streak, o
             onClick={onPlay}
             disabled={isPlayingDaily}
             data-testid="streak-banner-play"
-            className="group text-sm font-semibold text-indigo-600 dark:text-indigo-400 whitespace-nowrap flex-shrink-0 px-2 py-1 -mr-2 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-900/40 disabled:cursor-default disabled:hover:bg-transparent transition-colors"
+            className="group flex-shrink-0 self-stretch sm:self-auto bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:disabled:bg-indigo-700 text-white font-semibold text-sm sm:text-base px-5 py-2.5 rounded-lg shadow-sm hover:shadow disabled:cursor-default disabled:shadow-none transition-all whitespace-nowrap"
           >
             <span className="inline-block group-hover:translate-x-0.5 group-disabled:translate-x-0 transition-transform">
               {isPlayingDaily ? t('daily.playing') : t('daily.playCta')}


### PR DESCRIPTION
## Summary

- **Closes #124** — the streak banner is no longer a thin notice bar; it's a real hero module
- Completes the design-polish trifecta on this component (typography in #179, color in #180, proportions here)

## Before / After

**Before:** ~46px tall, everything `text-sm`, day label + streak text separated by a `·`, "Play today →" was a small text link with hover halo. Read as utility chrome.

**After:** ~100px desktop / ~140px mobile-stacked. Two-line content (small uppercase label + bold headline) on the left, filled primary button on the right. Stacks vertically below `sm:` breakpoint with the button going full-width.

```
┌────────────────────────────────────────────────┐
│  DAILY PUZZLE #9,612                           │
│  Start your streak       [ Play today → ]      │
└────────────────────────────────────────────────┘
```

## Why this layout

- **Small label + bold headline** — the streakNode (🔥 5 days streak / Start your streak) is the announcement, dayLabel is context. The pattern matches every modern app's "daily" surface (Wordle, NYT Mini, etc.)
- **Filled primary button** — was a hover-halo text link before; now an unmissable indigo CTA that matches the action's prominence
- **Mobile stack** — vertical flow with full-width button is the conventional mobile primary-CTA pattern, easier to tap

## A11y preserved

- Outer wrapper is still a plain `<div>` (no implicit click handler on info content)
- CTA's accessible name is exactly "Play today" / "Playing…" — not the concatenated everything (the #132 fix)
- Headline column is a flex with text-only spans — SR reads "Daily puzzle #9612, Start your streak"

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] 10/10 StreakBanner tests pass
- [x] Visual screenshot desktop + mobile both look hero-grade
- [ ] Manual: complete a daily, refresh — verify the green completed banner is still right (we didn't change that branch)
- [ ] Manual: tab to the banner — only the button gets focus, info content does not
- [ ] Manual VoiceOver: hear "Daily puzzle #9612, Start your streak" then "Play today, button" (separated)

## What's next

`#102` is essentially the same theme as this — "make daily streak the hero of the UI". With #124 closed, #102 either becomes redundant (close as duplicate) or scopes to broader UI re-architecture (e.g., move banner to top of every page). Up to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)