### PR TITLE
refactor(game): extract keyboard shortcuts to a hook

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -15,6 +15,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { useHowToPlay } from '../../hooks/useHowToPlay';
 import { useStats } from '../../hooks/useStats';
 import { useDaily } from '../../hooks/useDaily';
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { HowToPlayModal } from '../Controls/HowToPlayModal';
 import { StatsModal } from '../UI/StatsModal';
 import { StreakBanner } from '../UI/StreakBanner';
@@ -160,94 +161,17 @@ export function GameContainer() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount
 
-  // Undo/redo keyboard shortcuts (work without cell selection)
-  useEffect(() => {
-    const handleUndoRedo = (e: KeyboardEvent) => {
-      if (tourOpen) return;
-      if (state.gameStatus !== GAME_STATUS.PLAYING) return;
-      const ctrlOrMeta = e.ctrlKey || e.metaKey;
-      if (ctrlOrMeta && e.key === 'z' && !e.shiftKey) {
-        e.preventDefault();
-        actions.undo();
-      } else if (ctrlOrMeta && e.key === 'z' && e.shiftKey) {
-        e.preventDefault();
-        actions.redo();
-      } else if (ctrlOrMeta && e.key === 'y') {
-        e.preventDefault();
-        actions.redo();
-      }
-    };
-    window.addEventListener('keydown', handleUndoRedo);
-    return () => window.removeEventListener('keydown', handleUndoRedo);
-  }, [state.gameStatus, actions, tourOpen]);
-
-  // Handle keyboard input
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (tourOpen) return;
-      if (!state.selectedCell || state.gameStatus !== GAME_STATUS.PLAYING) {
-        return;
-      }
-
-      const { row, col } = state.selectedCell;
-
-      // Number keys 1-9
-      if (e.key >= '1' && e.key <= '9') {
-        e.preventDefault();
-        const num = parseInt(e.key);
-
-        if (state.notesMode) {
-          actions.setNote(row, col, num);
-        } else {
-          const isInitialCell = state.initialBoard[row][col] !== EMPTY_CELL;
-          if (!isInitialCell) {
-            pendingDigitSoundRef.current = true;
-            pendingHapticRef.current = true;
-          }
-          actions.setCellValue(row, col, num as 1|2|3|4|5|6|7|8|9, currentMistakeLimit);
-        }
-      }
-
-      // Backspace or Delete to clear cell
-      if (e.key === 'Backspace' || e.key === 'Delete' || e.key === '0') {
-        e.preventDefault();
-        actions.setCellValue(row, col, EMPTY_CELL, currentMistakeLimit);
-      }
-
-      // Arrow keys for navigation
-      if (e.key.startsWith('Arrow')) {
-        e.preventDefault();
-        let newRow = row;
-        let newCol = col;
-
-        switch (e.key) {
-          case 'ArrowUp':
-            newRow = Math.max(0, row - 1);
-            break;
-          case 'ArrowDown':
-            newRow = Math.min(8, row + 1);
-            break;
-          case 'ArrowLeft':
-            newCol = Math.max(0, col - 1);
-            break;
-          case 'ArrowRight':
-            newCol = Math.min(8, col + 1);
-            break;
-        }
-
-        actions.selectCell(newRow, newCol);
-      }
-
-      // 'n' key to toggle notes mode
-      if (e.key === 'n' || e.key === 'N') {
-        e.preventDefault();
-        actions.toggleNotesMode();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [state.selectedCell, state.gameStatus, state.notesMode, state.initialBoard, actions, currentMistakeLimit, tourOpen]);
+  // Keyboard shortcuts: undo/redo + cell input (digits, clear, arrows, n).
+  // Extracted to a hook so GameContainer stays focused on layout + flow
+  // orchestration, not raw keydown plumbing (#116 — first slice).
+  useKeyboardShortcuts({
+    state,
+    actions,
+    currentMistakeLimit,
+    tourOpen,
+    pendingDigitSoundRef,
+    pendingHapticRef,
+  });
 
   const handleCellClick = useCallback(
     (row: number, col: number) => {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,131 @@
+import { useEffect, type MutableRefObject } from 'react';
+import { GAME_STATUS, EMPTY_CELL } from '../utils/constants';
+import type { GameState, GameActions } from '../types/index';
+
+interface UseKeyboardShortcutsParams {
+  state: GameState;
+  actions: GameActions;
+  currentMistakeLimit: number | null;
+  tourOpen: boolean;
+  // Set inside the cell-input handler so the parent's completion effect
+  // can pick up "a digit was just placed" and route to sound/haptic.
+  // Refs (not state) so a write here doesn't trigger re-render and the
+  // ref-update lands synchronously before the effect's render closure.
+  pendingDigitSoundRef: MutableRefObject<boolean>;
+  pendingHapticRef: MutableRefObject<boolean>;
+}
+
+/**
+ * Centralizes the global keyboard shortcuts the GameContainer used to
+ * inline. Two listeners:
+ *
+ *   - Undo/redo (Ctrl+Z, Ctrl+Shift+Z, Ctrl+Y) — fires regardless of cell
+ *     selection, only requires PLAYING status. Why a separate listener:
+ *     these need to work even when no cell is selected (e.g. user just
+ *     loaded the page mid-game and wants to undo).
+ *
+ *   - Cell input (1-9, Backspace/Delete/0, arrows, n) — gated on a
+ *     selected cell + PLAYING status. Routes through actions.setCellValue
+ *     for digits / clear, actions.selectCell for arrow navigation, and
+ *     actions.toggleNotesMode for the 'n' key.
+ *
+ * Both gated on `tourOpen` so the onboarding tour can capture keys without
+ * the game grabbing them.
+ */
+export function useKeyboardShortcuts({
+  state,
+  actions,
+  currentMistakeLimit,
+  tourOpen,
+  pendingDigitSoundRef,
+  pendingHapticRef,
+}: UseKeyboardShortcutsParams): void {
+  // Undo/redo keyboard shortcuts (work without cell selection)
+  useEffect(() => {
+    const handleUndoRedo = (e: KeyboardEvent) => {
+      if (tourOpen) return;
+      if (state.gameStatus !== GAME_STATUS.PLAYING) return;
+      const ctrlOrMeta = e.ctrlKey || e.metaKey;
+      if (ctrlOrMeta && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        actions.undo();
+      } else if (ctrlOrMeta && e.key === 'z' && e.shiftKey) {
+        e.preventDefault();
+        actions.redo();
+      } else if (ctrlOrMeta && e.key === 'y') {
+        e.preventDefault();
+        actions.redo();
+      }
+    };
+    window.addEventListener('keydown', handleUndoRedo);
+    return () => window.removeEventListener('keydown', handleUndoRedo);
+  }, [state.gameStatus, actions, tourOpen]);
+
+  // Cell input handler (digits, clear, arrows, notes toggle)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (tourOpen) return;
+      if (!state.selectedCell || state.gameStatus !== GAME_STATUS.PLAYING) {
+        return;
+      }
+
+      const { row, col } = state.selectedCell;
+
+      // Number keys 1-9
+      if (e.key >= '1' && e.key <= '9') {
+        e.preventDefault();
+        const num = parseInt(e.key);
+
+        if (state.notesMode) {
+          actions.setNote(row, col, num);
+        } else {
+          const isInitialCell = state.initialBoard[row][col] !== EMPTY_CELL;
+          if (!isInitialCell) {
+            pendingDigitSoundRef.current = true;
+            pendingHapticRef.current = true;
+          }
+          actions.setCellValue(row, col, num as 1|2|3|4|5|6|7|8|9, currentMistakeLimit);
+        }
+      }
+
+      // Backspace or Delete to clear cell
+      if (e.key === 'Backspace' || e.key === 'Delete' || e.key === '0') {
+        e.preventDefault();
+        actions.setCellValue(row, col, EMPTY_CELL, currentMistakeLimit);
+      }
+
+      // Arrow keys for navigation
+      if (e.key.startsWith('Arrow')) {
+        e.preventDefault();
+        let newRow = row;
+        let newCol = col;
+
+        switch (e.key) {
+          case 'ArrowUp':
+            newRow = Math.max(0, row - 1);
+            break;
+          case 'ArrowDown':
+            newRow = Math.min(8, row + 1);
+            break;
+          case 'ArrowLeft':
+            newCol = Math.max(0, col - 1);
+            break;
+          case 'ArrowRight':
+            newCol = Math.min(8, col + 1);
+            break;
+        }
+
+        actions.selectCell(newRow, newCol);
+      }
+
+      // 'n' key to toggle notes mode
+      if (e.key === 'n' || e.key === 'N') {
+        e.preventDefault();
+        actions.toggleNotesMode();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [state.selectedCell, state.gameStatus, state.notesMode, state.initialBoard, actions, currentMistakeLimit, tourOpen, pendingDigitSoundRef, pendingHapticRef]);
+}


### PR DESCRIPTION
## Summary

- **First slice of #116** — GameContainer refactor done as a series of focused PRs instead of one mega-extraction
- This PR moves the two `useEffect` keyboard listeners (undo/redo + cell input) into `src/hooks/useKeyboardShortcuts.ts`
- Behavior unchanged; tests pass; GameContainer drops 728 → 652 LOC

## Why incremental

The /retro flagged GameContainer as a 22-commits-in-14-days gravity well. Refactoring the whole file in one PR would be a multi-hour review and a giant blast radius for any subtle regression. Slice-per-PR keeps each review trivial and the bisect-finger pointed at one extraction at a time.

## What this slice covers

| Effect | Handler | Trigger gate |
|---|---|---|
| 1 | Undo/redo (Ctrl+Z, Ctrl+Shift+Z, Ctrl+Y) | `PLAYING && !tourOpen` |
| 2 | Cell input (1-9, Backspace/Delete/0, arrows, n) | `selectedCell && PLAYING && !tourOpen` |

Both `window.addEventListener('keydown')` + cleanup on unmount.

## Why these two together (one hook, not two)

They're peer-level global keydown listeners. Splitting them would re-create the boilerplate. Co-locating makes future shortcut work go in one file.

## Why two refs are passed in (not owned by the hook)

`pendingDigitSoundRef` and `pendingHapticRef` are also read by the completion effect inside GameContainer. Hook-ownership would require returning them back, which is more plumbing than passing in. Refs have stable identity → no dep-array churn.

## What's identical to before

- Effect dep arrays (line-for-line)
- Gating logic (line-for-line)
- preventDefault calls in the same places
- Same actions invoked, same args

A future regression would have to break the hook itself, not the inline code.

## Next slices (planned, separate PRs)

- `usePuzzleLifecycle` — handleStartDaily / handleNewGame / handleDifficulty / handleType + completion-effect daily branch
- `useShare` — handleShare + ShareToast state
- `useAutoStartIdle` — IDLE→newGame effect with deep-link parsing

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] Full unit suite passes
- [x] GameContainer drops to 652 LOC, hook file is 131 LOC
- [ ] Manual: in-game press Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y → undo/redo fire
- [ ] Manual: select a cell, press 1-9 → digit lands; press Backspace → cell clears; arrow keys move; 'n' toggles notes mode
- [ ] Manual: same shortcuts during onboarding tour → game does NOT grab them (tourOpen gate works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)