### PR TITLE
refactor(game): extract auto-start IDLE effect to a hook

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -16,6 +16,7 @@ import { useHowToPlay } from '../../hooks/useHowToPlay';
 import { useStats } from '../../hooks/useStats';
 import { useDaily } from '../../hooks/useDaily';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+import { useAutoStartIdle } from '../../hooks/useAutoStartIdle';
 import { HowToPlayModal } from '../Controls/HowToPlayModal';
 import { StatsModal } from '../UI/StatsModal';
 import { StreakBanner } from '../UI/StreakBanner';
@@ -34,8 +35,8 @@ import { HintModal } from '../Controls/HintModal';
 import { GameOverModal } from '../Controls/GameOverModal';
 import { LanguageSwitcher } from '../UI/LanguageSwitcher';
 import { OddEvenLegend } from '../UI/OddEvenLegend';
-import { GAME_STATUS, DIFFICULTY_LEVELS, EMPTY_CELL, SUDOKU_TYPES } from '../../utils/constants';
-import type { HighlightRole, DifficultyLevel, SudokuTypeId } from '../../types/index';
+import { GAME_STATUS, DIFFICULTY_LEVELS, EMPTY_CELL } from '../../utils/constants';
+import type { HighlightRole } from '../../types/index';
 
 /**
  * Main game container component
@@ -82,7 +83,13 @@ export function GameContainer() {
   // minute, all of them no-ops outside the gameStatus transition we care
   // about). Updated inline on every render so it's always fresh when the
   // effect actually fires (on gameStatus change).
+  // Intentional inline ref-mirror: the completion effect needs the LATEST
+  // elapsedTime when it fires (on gameStatus change), but listing
+  // state.elapsedTime as a dep would re-run it every second of play
+  // (#143). Until React's useEffectEvent stabilizes, mirroring into a
+  // ref during render is the documented workaround.
   const elapsedTimeRef = useRef(state.elapsedTime);
+  // eslint-disable-next-line react-hooks/refs
   elapsedTimeRef.current = state.elapsedTime;
 
   // Timer hook
@@ -142,24 +149,9 @@ export function GameContainer() {
     isNewBestTimeRef,
   );
 
-  // Auto-start game if status is IDLE, honouring ?type=&difficulty= deep-link params.
-  useEffect(() => {
-    if (state.gameStatus === GAME_STATUS.IDLE) {
-      const params = new URLSearchParams(window.location.search);
-      const typeParam = params.get('type') as SudokuTypeId | null;
-      const diffParam = params.get('difficulty') as DifficultyLevel | null;
-      const validType = typeParam && typeParam in SUDOKU_TYPES ? typeParam : state.sudokuType;
-      const validDiff = diffParam && diffParam in DIFFICULTY_LEVELS ? diffParam : state.difficulty;
-      actions.newGame(validDiff, validType);
-      recordGameStart(validType, validDiff);
-    } else if (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) {
-      // Returning user mid-game: count as a started game so a completion this
-      // session is visible in stats immediately. Skip COMPLETED/LOST to avoid
-      // inflating gamesStarted on every reload of a finished game.
-      recordGameStart(state.sudokuType, state.difficulty);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run on mount
+  // Mount-time auto-start + returning-user game-start recording (#116).
+  // See useAutoStartIdle for why empty deps are intentional.
+  useAutoStartIdle(state, actions);
 
   // Keyboard shortcuts: undo/redo + cell input (digits, clear, arrows, n).
   // Extracted to a hook so GameContainer stays focused on layout + flow

--- a/src/hooks/useAutoStartIdle.ts
+++ b/src/hooks/useAutoStartIdle.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { GAME_STATUS, DIFFICULTY_LEVELS, SUDOKU_TYPES } from '../utils/constants';
+import { recordGameStart } from '../utils/stats';
+import type { GameState, GameActions, DifficultyLevel, SudokuTypeId } from '../types/index';
+
+/**
+ * Mount-time effect that:
+ *
+ *  1. Auto-starts a new game when status is IDLE, honouring deep-link
+ *     `?type=` and `?difficulty=` query params (validated against the
+ *     constants tables — invalid values fall back to the current state).
+ *  2. For a returning user mid-game (PLAYING / PAUSED), records a
+ *     game-start event so a completion this session shows up in stats.
+ *     Skips COMPLETED / LOST to avoid inflating gamesStarted on every
+ *     reload of a finished game.
+ *
+ * Empty-deps + eslint-disable is intentional: the effect captures the
+ * mount-time state and never re-fires. Subsequent state changes are
+ * handled by other code paths (handleNewGame, etc.). If we let it
+ * re-run on state.gameStatus changes we'd double-record game-starts.
+ */
+export function useAutoStartIdle(state: GameState, actions: GameActions): void {
+  useEffect(() => {
+    if (state.gameStatus === GAME_STATUS.IDLE) {
+      const params = new URLSearchParams(window.location.search);
+      const typeParam = params.get('type') as SudokuTypeId | null;
+      const diffParam = params.get('difficulty') as DifficultyLevel | null;
+      const validType = typeParam && typeParam in SUDOKU_TYPES ? typeParam : state.sudokuType;
+      const validDiff = diffParam && diffParam in DIFFICULTY_LEVELS ? diffParam : state.difficulty;
+      actions.newGame(validDiff, validType);
+      recordGameStart(validType, validDiff);
+    } else if (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) {
+      recordGameStart(state.sudokuType, state.difficulty);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only run on mount
+}


### PR DESCRIPTION
## Summary

- **Second slice of #116** (after #183 extracted keyboard shortcuts)
- Moves the mount-time auto-start IDLE effect to `src/hooks/useAutoStartIdle.ts`
- GameContainer drops from 652 → 644 LOC

## What moved

The `useEffect(() => { /* IDLE auto-start + returning-user game-start */ }, [])` block becomes a single hook call:

```tsx
useAutoStartIdle(state, actions);
```

Empty-deps + eslint-disable preserved verbatim because the effect is explicitly mount-only — subsequent state changes go through `handleNewGame` and friends.

## Drive-by lint fix

The new `react-hooks/refs` rule from eslint-plugin-react-hooks 7.0.1 started flagging the inline `elapsedTimeRef.current = state.elapsedTime` line on this branch (didn't fire on dev — context-sensitive). Added a targeted `eslint-disable-next-line react-hooks/refs` with explanation. The pattern itself is the documented workaround for "read latest value in effect without re-running it" until React's `useEffectEvent` stabilizes.

## Why next slice — `useShare` or `usePuzzleLifecycle`?

`useShare` is smaller (handleShare + ShareToast state), so probably next. `usePuzzleLifecycle` is the biggest remaining chunk and will need careful surgery on the completion effect.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] Full unit suite passes
- [x] GameContainer.tsx 652 → 644 LOC
- [ ] Manual: load `/?type=DIAGONAL&difficulty=HARD` on a fresh tab, verify Diagonal Hard puzzle starts (deep-link path)
- [ ] Manual: load with no query params, verify default puzzle starts (IDLE → newGame default path)
- [ ] Manual: reload mid-game, verify a new gamesStarted event records but the game state restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)