### PR TITLE
refactor(game): extract handleShare + toast to useShare

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -17,12 +17,12 @@ import { useStats } from '../../hooks/useStats';
 import { useDaily } from '../../hooks/useDaily';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useAutoStartIdle } from '../../hooks/useAutoStartIdle';
+import { useShare } from '../../hooks/useShare';
 import { HowToPlayModal } from '../Controls/HowToPlayModal';
 import { StatsModal } from '../UI/StatsModal';
 import { StreakBanner } from '../UI/StreakBanner';
 import { recordGameStart, recordGameComplete } from '../../utils/stats';
 import { updateBestTime } from '../../utils/bestTime';
-import { shareOrCopy, buildShareUrl, formatElapsed } from '../../utils/share';
 import { ShareToast } from '../UI/ShareToast';
 import { SettingsDrawer } from '../UI/SettingsDrawer';
 import { Board } from '../Board/Board';
@@ -63,7 +63,11 @@ export function GameContainer() {
   // started, not the day it was solved on.
   const playingDailyDateRef = useRef<string | null>(null);
 
-  const [shareToastVisible, setShareToastVisible] = useState(false);
+  const { handleShare, shareToastVisible } = useShare({
+    sudokuType: state.sudokuType,
+    difficulty: state.difficulty,
+    elapsedTime: state.elapsedTime,
+  });
 
   // Resolved limit passed to the reducer on every placement. null when
   // the preference is off, so the reducer will not transition to LOST.
@@ -229,19 +233,6 @@ export function GameContainer() {
     actions.newGame(dailyInfo.difficulty, dailyInfo.type, dailyInfo.seed);
     recordGameStart(dailyInfo.type, dailyInfo.difficulty);
   }, [dailyInfo, actions, state.gameStatus, state.historyIndex, t]);
-
-  const handleShare = useCallback(async () => {
-    const typeName = t(`sudokuTypes.${state.sudokuType}.name`);
-    const diffName = t(`difficulty.${state.difficulty}`);
-    const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
-    const url = buildShareUrl(state.sudokuType, state.difficulty, baseUrl);
-    const text = t('game.shareText', { type: typeName, difficulty: diffName, time: formatElapsed(state.elapsedTime) });
-    const outcome = await shareOrCopy(text, url);
-    if (outcome === 'copied') {
-      setShareToastVisible(true);
-      setTimeout(() => setShareToastVisible(false), 2500);
-    }
-  }, [t, state.sudokuType, state.difficulty, state.elapsedTime]);
 
   const handleDifficultyChange = useCallback(
     (difficulty: Parameters<typeof actions.newGame>[0]) => {

--- a/src/hooks/useShare.test.ts
+++ b/src/hooks/useShare.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useShare } from './useShare';
+import * as shareUtils from '../utils/share';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+describe('useShare', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('toast stays hidden until handleShare is invoked', () => {
+    const { result } = renderHook(() =>
+      useShare({ sudokuType: 'CLASSIC', difficulty: 'EASY', elapsedTime: 0 }),
+    );
+    expect(result.current.shareToastVisible).toBe(false);
+  });
+
+  it('shows toast for 2.5s when outcome is "copied", then hides', async () => {
+    vi.spyOn(shareUtils, 'shareOrCopy').mockResolvedValue('copied');
+
+    const { result } = renderHook(() =>
+      useShare({ sudokuType: 'CLASSIC', difficulty: 'HARD', elapsedTime: 120 }),
+    );
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(result.current.shareToastVisible).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(result.current.shareToastVisible).toBe(false);
+  });
+
+  it('does not show toast when outcome is "shared"', async () => {
+    vi.spyOn(shareUtils, 'shareOrCopy').mockResolvedValue('shared');
+
+    const { result } = renderHook(() =>
+      useShare({ sudokuType: 'CLASSIC', difficulty: 'EASY', elapsedTime: 60 }),
+    );
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(result.current.shareToastVisible).toBe(false);
+  });
+
+  it('does not show toast when outcome is "cancelled" or "failed"', async () => {
+    const spy = vi.spyOn(shareUtils, 'shareOrCopy').mockResolvedValue('cancelled');
+
+    const { result } = renderHook(() =>
+      useShare({ sudokuType: 'CLASSIC', difficulty: 'EASY', elapsedTime: 60 }),
+    );
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+    expect(result.current.shareToastVisible).toBe(false);
+
+    spy.mockResolvedValue('failed');
+    await act(async () => {
+      await result.current.handleShare();
+    });
+    expect(result.current.shareToastVisible).toBe(false);
+  });
+
+  it('passes the deep-link URL and i18n share text to shareOrCopy', async () => {
+    const spy = vi.spyOn(shareUtils, 'shareOrCopy').mockResolvedValue('shared');
+
+    const { result } = renderHook(() =>
+      useShare({ sudokuType: 'DIAGONAL', difficulty: 'EXPERT', elapsedTime: 443 }),
+    );
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [text, url] = spy.mock.calls[0];
+    expect(url).toContain('?type=DIAGONAL&difficulty=EXPERT');
+    // 443s → 7:23 via formatElapsed
+    expect(text).toContain('7:23');
+  });
+});

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { shareOrCopy, buildShareUrl, formatElapsed } from '../utils/share';
+import type { DifficultyLevel, SudokuTypeId } from '../types/index';
+
+interface UseShareParams {
+  sudokuType: SudokuTypeId;
+  difficulty: DifficultyLevel;
+  elapsedTime: number;
+}
+
+interface UseShareReturn {
+  handleShare: () => Promise<void>;
+  shareToastVisible: boolean;
+}
+
+/**
+ * Owns the "share my completed game" button: builds the deep-link + share text,
+ * delegates to the navigator.share / clipboard fallback in utils/share, and
+ * shows the "copied!" toast for 2.5s when we hit the clipboard branch.
+ *
+ * Toast visibility is local state instead of being lifted because nothing
+ * outside the share button cares about it.
+ */
+export function useShare({ sudokuType, difficulty, elapsedTime }: UseShareParams): UseShareReturn {
+  const { t } = useTranslation();
+  const [shareToastVisible, setShareToastVisible] = useState(false);
+
+  const handleShare = useCallback(async () => {
+    const typeName = t(`sudokuTypes.${sudokuType}.name`);
+    const diffName = t(`difficulty.${difficulty}`);
+    const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+    const url = buildShareUrl(sudokuType, difficulty, baseUrl);
+    const text = t('game.shareText', { type: typeName, difficulty: diffName, time: formatElapsed(elapsedTime) });
+    const outcome = await shareOrCopy(text, url);
+    if (outcome === 'copied') {
+      setShareToastVisible(true);
+      setTimeout(() => setShareToastVisible(false), 2500);
+    }
+  }, [t, sudokuType, difficulty, elapsedTime]);
+
+  return { handleShare, shareToastVisible };
+}


### PR DESCRIPTION
## Summary

Third slice of #116 (the GameContainer refactor). Moves the share-button orchestration out of `GameContainer` into a new `useShare` hook.

- New `src/hooks/useShare.ts` (~45 LOC) — owns `handleShare` + `shareToastVisible`. Narrow input shape `{ sudokuType, difficulty, elapsedTime }` instead of full `GameState` so the hook is decoupled from the reducer and trivial to test.
- `GameContainer.tsx`: dropped the inline `useState` + `useCallback` block and the `shareOrCopy/buildShareUrl/formatElapsed` imports; replaced with one line calling `useShare(…)`. Net **−9 LOC** (644 → 635).
- New `src/hooks/useShare.test.ts` — 5 unit tests:
  - toast hidden initially
  - toast shows for 2.5s on `'copied'`, hides after the timer fires
  - toast stays hidden on `'shared'`, `'cancelled'`, `'failed'`
  - deep-link URL + i18n share text passed correctly to `shareOrCopy`

No behavioral change. Same `setTimeout` pattern (no cleanup) as before — preserving exact behavior is the point of this refactor; if we want to clean the timeout on unmount or de-dupe rapid clicks that's a separate change.

## Why next slice — `usePuzzleLifecycle`?

That's the biggest remaining chunk in `GameContainer`: `handleStartDaily` / `handleNewGame` / `handleDifficultyChange` / `handleTypeChange` + the daily branch of the completion effect. It's the trickiest because it touches both the daily refs (`isPlayingDailyRef`, `playingDailyDateRef`) and the completion side-effect routing. Worth doing carefully in its own PR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/hooks/useShare.ts src/hooks/useShare.test.ts src/components/Game/GameContainer.tsx` clean
- [x] `npx vitest run src/hooks/useShare.test.ts` — 5/5 pass
- [x] Full unit suite still green (no regressions)
- [ ] Manual smoke: complete a game, hit Share → toast appears, fades after ~2.5s; share text/URL look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)