### PR TITLE
refactor(game): extract usePuzzleLifecycle (final slice of #116)

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -18,10 +18,11 @@ import { useDaily } from '../../hooks/useDaily';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useAutoStartIdle } from '../../hooks/useAutoStartIdle';
 import { useShare } from '../../hooks/useShare';
+import { usePuzzleLifecycle } from '../../hooks/usePuzzleLifecycle';
 import { HowToPlayModal } from '../Controls/HowToPlayModal';
 import { StatsModal } from '../UI/StatsModal';
 import { StreakBanner } from '../UI/StreakBanner';
-import { recordGameStart, recordGameComplete } from '../../utils/stats';
+import { recordGameComplete } from '../../utils/stats';
 import { updateBestTime } from '../../utils/bestTime';
 import { ShareToast } from '../UI/ShareToast';
 import { SettingsDrawer } from '../UI/SettingsDrawer';
@@ -56,12 +57,20 @@ export function GameContainer() {
   const { store: statsStore, reload: reloadStats, reset: resetStats } = useStats();
   const { dailyInfo, isCompleted: isDailyCompleted, streak: dailyStreak, markCompleted: markDailyCompleted } = useDaily();
   const [statsOpen, setStatsOpen] = useState(false);
-  const [isPlayingDaily, setIsPlayingDaily] = useState(false);
-  const isPlayingDailyRef = useRef(false);
-  // Captured at game start. Used at completion instead of dailyInfo.date so
-  // a midnight rollover mid-game records against the day the puzzle was
-  // started, not the day it was solved on.
-  const playingDailyDateRef = useRef<string | null>(null);
+
+  const {
+    isPlayingDaily,
+    handleNewGame,
+    handleStartDaily,
+    handleDifficultyChange,
+    handleTypeChange,
+  } = usePuzzleLifecycle({
+    state,
+    actions,
+    dailyInfo,
+    markDailyCompleted,
+    triggerAutoShow,
+  });
 
   const { handleShare, shareToastVisible } = useShare({
     sudokuType: state.sudokuType,
@@ -115,12 +124,6 @@ export function GameContainer() {
       // depend on the timer tick (see #143).
       isNewBestTimeRef.current = updateBestTime(state.difficulty, elapsedTimeRef.current);
       recordGameComplete(state.sudokuType, state.difficulty, elapsedTimeRef.current, state.mistakeCount);
-      if (isPlayingDailyRef.current && playingDailyDateRef.current) {
-        markDailyCompleted(playingDailyDateRef.current);
-        isPlayingDailyRef.current = false;
-        playingDailyDateRef.current = null;
-        setIsPlayingDaily(false);
-      }
       playVictorySound();
       vibrateComplete();
     } else if (pendingDigitSoundRef.current || pendingHapticRef.current) {
@@ -139,11 +142,9 @@ export function GameContainer() {
     prevGameStatusRef.current = state.gameStatus;
     prevErrorsSizeRef.current = state.errors.size;
     // state.elapsedTime intentionally NOT in deps — read via elapsedTimeRef
-    // so the effect doesn't fire on every timer tick (#143).
-    // dailyInfo.date intentionally NOT in deps — completion uses the captured
-    // playingDailyDateRef so midnight refresh of dailyInfo doesn't change which
-    // day gets credited.
-  }, [state.errors, state.gameStatus, state.difficulty, state.sudokuType, state.mistakeCount, markDailyCompleted, playVictorySound, playErrorSound, playDigitSound, vibrateComplete, vibrateError, vibrateDigit]);
+    // so the effect doesn't fire on every timer tick (#143). Daily-completion
+    // routing now lives in usePuzzleLifecycle.
+  }, [state.errors, state.gameStatus, state.difficulty, state.sudokuType, state.mistakeCount, playVictorySound, playErrorSound, playDigitSound, vibrateComplete, vibrateError, vibrateDigit]);
 
   // Confetti on completion — declared AFTER the sound effect so React runs it
   // second, giving the sound effect a chance to update isNewBestTimeRef first.
@@ -205,69 +206,6 @@ export function GameContainer() {
       actions.setCellValue(row, col, EMPTY_CELL, currentMistakeLimit);
     }
   }, [state.selectedCell, state.gameStatus, actions, currentMistakeLimit]);
-
-  const handleNewGame = useCallback(() => {
-    if (
-      (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) &&
-      state.historyIndex > 0 &&
-      !window.confirm(t(isPlayingDailyRef.current ? 'game.confirmExitDaily' : 'game.confirmNewGame'))
-    ) return;
-    isPlayingDailyRef.current = false;
-    playingDailyDateRef.current = null;
-    setIsPlayingDaily(false);
-    actions.newGame(state.difficulty, state.sudokuType);
-    recordGameStart(state.sudokuType, state.difficulty);
-  }, [state.difficulty, state.sudokuType, state.gameStatus, state.historyIndex, actions, t]);
-
-  const handleStartDaily = useCallback(() => {
-    if (
-      (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) &&
-      state.historyIndex > 0 &&
-      !window.confirm(t('game.confirmNewGame'))
-    ) return;
-    isPlayingDailyRef.current = true;
-    // Snapshot the puzzle's date NOW so a midnight rollover during play
-    // doesn't change which day completion credits.
-    playingDailyDateRef.current = dailyInfo.date;
-    setIsPlayingDaily(true);
-    actions.newGame(dailyInfo.difficulty, dailyInfo.type, dailyInfo.seed);
-    recordGameStart(dailyInfo.type, dailyInfo.difficulty);
-  }, [dailyInfo, actions, state.gameStatus, state.historyIndex, t]);
-
-  const handleDifficultyChange = useCallback(
-    (difficulty: Parameters<typeof actions.newGame>[0]) => {
-      if (
-        (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) &&
-        state.historyIndex > 0 &&
-        !window.confirm(t(isPlayingDailyRef.current ? 'game.confirmExitDaily' : 'game.confirmNewGame'))
-      ) return;
-      isPlayingDailyRef.current = false;
-      playingDailyDateRef.current = null;
-      setIsPlayingDaily(false);
-      actions.newGame(difficulty, state.sudokuType);
-      if (difficulty) recordGameStart(state.sudokuType, difficulty);
-    },
-    [state.sudokuType, state.gameStatus, state.historyIndex, actions, t]
-  );
-
-  const handleTypeChange = useCallback(
-    (sudokuType: Parameters<typeof actions.newGame>[1]) => {
-      if (
-        (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) &&
-        state.historyIndex > 0 &&
-        !window.confirm(t(isPlayingDailyRef.current ? 'game.confirmExitDaily' : 'game.confirmNewGame'))
-      ) return;
-      isPlayingDailyRef.current = false;
-      playingDailyDateRef.current = null;
-      setIsPlayingDaily(false);
-      actions.newGame(state.difficulty, sudokuType);
-      if (sudokuType) {
-        recordGameStart(sudokuType, state.difficulty);
-        triggerAutoShow(sudokuType);
-      }
-    },
-    [state.difficulty, state.gameStatus, state.historyIndex, actions, t, triggerAutoShow]
-  );
 
   const maxHints = DIFFICULTY_LEVELS[state.difficulty].maxHints;
 

--- a/src/hooks/usePuzzleLifecycle.test.ts
+++ b/src/hooks/usePuzzleLifecycle.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePuzzleLifecycle } from './usePuzzleLifecycle';
+import { GAME_STATUS } from '../utils/constants';
+import * as stats from '../utils/stats';
+import type { GameState, GameActions } from '../types/index';
+import type { DailyInfo } from '../utils/dailyPuzzle';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    board: [],
+    initialBoard: [],
+    solution: [],
+    selectedCell: null,
+    difficulty: 'EASY',
+    sudokuType: 'CLASSIC',
+    gameStatus: GAME_STATUS.IDLE,
+    elapsedTime: 0,
+    hintsUsed: 0,
+    errors: new Set(),
+    mistakeCount: 0,
+    notesMode: false,
+    notes: new Map(),
+    activeHint: null,
+    oddEvenMarkers: null,
+    kropkiDots: null,
+    killerCages: null,
+    littleKillerClues: null,
+    greaterThanSigns: null,
+    thermos: null,
+    sandwichClues: null,
+    history: [],
+    historyIndex: 0,
+    ...overrides,
+  } as GameState;
+}
+
+function makeActions(): GameActions {
+  return {
+    newGame: vi.fn(),
+    setCellValue: vi.fn(),
+    selectCell: vi.fn(),
+    checkSolution: vi.fn(),
+    getHint: vi.fn(),
+    applyHint: vi.fn(),
+    dismissHint: vi.fn(),
+    toggleNotesMode: vi.fn(),
+    setNote: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    pauseGame: vi.fn(),
+    resumeGame: vi.fn(),
+    updateTime: vi.fn(),
+  } as GameActions;
+}
+
+const dailyInfo: DailyInfo = {
+  date: '2026-04-27',
+  dayNumber: 9613,
+  seed: 42,
+  type: 'CLASSIC',
+  difficulty: 'MEDIUM',
+};
+
+describe('usePuzzleLifecycle', () => {
+  let confirmSpy: MockInstance<typeof window.confirm>;
+  let recordStartSpy: MockInstance<typeof stats.recordGameStart>;
+
+  beforeEach(() => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    recordStartSpy = vi.spyOn(stats, 'recordGameStart').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initial state — not playing daily', () => {
+    const { result } = renderHook(() =>
+      usePuzzleLifecycle({
+        state: makeState(),
+        actions: makeActions(),
+        dailyInfo,
+        markDailyCompleted: vi.fn(),
+        triggerAutoShow: vi.fn(),
+      }),
+    );
+    expect(result.current.isPlayingDaily).toBe(false);
+  });
+
+  it('handleStartDaily flips isPlayingDaily, calls newGame with seed, records start', () => {
+    const actions = makeActions();
+    const { result } = renderHook(() =>
+      usePuzzleLifecycle({
+        state: makeState(),
+        actions,
+        dailyInfo,
+        markDailyCompleted: vi.fn(),
+        triggerAutoShow: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.handleStartDaily());
+
+    expect(result.current.isPlayingDaily).toBe(true);
+    expect(actions.newGame).toHaveBeenCalledWith('MEDIUM', 'CLASSIC', 42);
+    expect(recordStartSpy).toHaveBeenCalledWith('CLASSIC', 'MEDIUM');
+  });
+
+  it('handleNewGame skips when user dismisses confirm mid-game', () => {
+    confirmSpy.mockReturnValue(false);
+    const actions = makeActions();
+    const { result } = renderHook(() =>
+      usePuzzleLifecycle({
+        state: makeState({ gameStatus: GAME_STATUS.PLAYING, historyIndex: 5 }),
+        actions,
+        dailyInfo,
+        markDailyCompleted: vi.fn(),
+        triggerAutoShow: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.handleNewGame());
+
+    expect(actions.newGame).not.toHaveBeenCalled();
+    expect(recordStartSpy).not.toHaveBeenCalled();
+  });
+
+  it('confirm guard fires for PAUSED state too', () => {
+    confirmSpy.mockReturnValue(false);
+    const actions = makeActions();
+    const { result } = renderHook(() =>
+      usePuzzleLifecycle({
+        state: makeState({ gameStatus: GAME_STATUS.PAUSED, historyIndex: 3 }),
+        actions,
+        dailyInfo,
+        markDailyCompleted: vi.fn(),
+        triggerAutoShow: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.handleDifficultyChange('HARD'));
+    expect(actions.newGame).not.toHaveBeenCalled();
+  });
+
+  it('confirm guard does not fire when historyIndex is 0', () => {
+    const actions = makeActions();
+    const { result } = renderHook(() =>
+      usePuzzleLifecycle({
+        state: makeState({ gameStatus: GAME_STATUS.PLAYING, historyIndex: 0 }),
+        actions,
+        dailyInfo,
+        markDailyCompleted: vi.fn(),
+        triggerAutoShow: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.handleNewGame());
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(actions.newGame).toHaveBeenCalled();
+  });
+
+  it('exit-daily confirm copy: handleNewGame uses confirmExitDaily when daily is in flight', () => {
+    confirmSpy.mockReturnValue(true);
+    const actions = makeActions();
+
+    const { result, rerender } = renderHook(
+      ({ state }: { state: GameState }) =>
+        usePuzzleLifecycle({
+          state,
+          actions,
+          dailyInfo,
+          markDailyCompleted: vi.fn(),
+          triggerAutoShow: vi.fn(),
+        }),
+      { initialProps: { state: makeState() } },
+    );
+
+    // Start a daily — flips ref
+    act(() => result.current.handleStartDaily());
+
+    // Now in-progress; rerender with PLAYING + historyIndex>0
+    rerender({ state: makeState({ gameStatus: GAME_STATUS.PLAYING, historyIndex: 4 }) });
+
+    act(() => result.current.handleNewGame());
+    expect(confirmSpy).toHaveBeenCalledWith('game.confirmExitDaily');
+  });
+
+  it('handleStartDaily uses confirmNewGame copy (never confirmExitDaily)', () => {
+    confirmSpy.mockReturnValue(true);
+    const { result } = renderHook(() =>
+      usePuzzleLifecycle({
+        state: makeState({ gameStatus: GAME_STATUS.PLAYING, historyIndex: 4 }),
+        actions: makeActions(),
+        dailyInfo,
+        markDailyCompleted: vi.fn(),
+        triggerAutoShow: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.handleStartDaily());
+    expect(confirmSpy).toHaveBeenCalledWith('game.confirmNewGame');
+  });
+
+  it('handleTypeChange triggers auto-show for the new type', () => {
+    const triggerAutoShow = vi.fn();
+    const { result } = renderHook(() =>
+      usePuzzleLifecycle({
+        state: makeState(),
+        actions: makeActions(),
+        dailyInfo,
+        markDailyCompleted: vi.fn(),
+        triggerAutoShow,
+      }),
+    );
+
+    act(() => result.current.handleTypeChange('DIAGONAL'));
+    expect(triggerAutoShow).toHaveBeenCalledWith('DIAGONAL');
+  });
+
+  it('completion of a daily calls markDailyCompleted with captured date and clears flag', () => {
+    const markDailyCompleted = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ state }: { state: GameState }) =>
+        usePuzzleLifecycle({
+          state,
+          actions: makeActions(),
+          dailyInfo,
+          markDailyCompleted,
+          triggerAutoShow: vi.fn(),
+        }),
+      { initialProps: { state: makeState() } },
+    );
+
+    act(() => result.current.handleStartDaily());
+    expect(result.current.isPlayingDaily).toBe(true);
+
+    // Capture date snapshot before midnight rollover
+    const startedDate = dailyInfo.date;
+
+    // Simulate completion — gameStatus → COMPLETED
+    rerender({ state: makeState({ gameStatus: GAME_STATUS.COMPLETED }) });
+
+    expect(markDailyCompleted).toHaveBeenCalledWith(startedDate);
+    expect(result.current.isPlayingDaily).toBe(false);
+  });
+
+  it('completion of a non-daily game does NOT call markDailyCompleted', () => {
+    const markDailyCompleted = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ state }: { state: GameState }) =>
+        usePuzzleLifecycle({
+          state,
+          actions: makeActions(),
+          dailyInfo,
+          markDailyCompleted,
+          triggerAutoShow: vi.fn(),
+        }),
+      { initialProps: { state: makeState({ gameStatus: GAME_STATUS.PLAYING }) } },
+    );
+
+    expect(result.current.isPlayingDaily).toBe(false);
+
+    rerender({ state: makeState({ gameStatus: GAME_STATUS.COMPLETED }) });
+    expect(markDailyCompleted).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePuzzleLifecycle.ts
+++ b/src/hooks/usePuzzleLifecycle.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { GAME_STATUS } from '../utils/constants';
+import { recordGameStart } from '../utils/stats';
+import type { GameState, GameActions, DifficultyLevel, SudokuTypeId } from '../types/index';
+import type { DailyInfo } from '../utils/dailyPuzzle';
+
+interface UsePuzzleLifecycleParams {
+  state: GameState;
+  actions: GameActions;
+  dailyInfo: DailyInfo;
+  markDailyCompleted: (date: string) => void;
+  triggerAutoShow: (sudokuType: SudokuTypeId) => void;
+}
+
+interface UsePuzzleLifecycleReturn {
+  isPlayingDaily: boolean;
+  handleNewGame: () => void;
+  handleStartDaily: () => void;
+  handleDifficultyChange: (difficulty?: DifficultyLevel) => void;
+  handleTypeChange: (sudokuType?: SudokuTypeId) => void;
+}
+
+/**
+ * Owns the "what puzzle are we currently playing" lifecycle. Four user
+ * intents start a new game (New Game button, Daily CTA, difficulty switch,
+ * type switch); each one needs the same in-progress confirmation guard,
+ * the same daily-flag reset, and a stats event. This hook centralizes all
+ * of that.
+ *
+ * Daily-completion routing is also owned here: when gameStatus transitions
+ * to COMPLETED while a daily is in flight, mark the captured day done and
+ * clear the flag. The captured date (`playingDailyDateRef`) is snapshotted
+ * at game-start so a midnight rollover during play credits the day the
+ * puzzle was started, not the day it was solved on (#147).
+ *
+ * Refs vs state:
+ *   - `isPlayingDailyRef` mirrors `isPlayingDaily` for the completion
+ *     effect, which can't depend on the live state without re-running on
+ *     every keystroke / status flip.
+ *   - `playingDailyDateRef` is ref-only: nothing renders from it; the
+ *     completion effect just needs the captured date.
+ */
+export function usePuzzleLifecycle({
+  state,
+  actions,
+  dailyInfo,
+  markDailyCompleted,
+  triggerAutoShow,
+}: UsePuzzleLifecycleParams): UsePuzzleLifecycleReturn {
+  const { t } = useTranslation();
+
+  const [isPlayingDaily, setIsPlayingDaily] = useState(false);
+  const isPlayingDailyRef = useRef(false);
+  const playingDailyDateRef = useRef<string | null>(null);
+
+  // Tracks the previous gameStatus so the daily-completion effect only
+  // fires on the IDLE/PLAYING/PAUSED → COMPLETED transition, not on every
+  // re-render where status is already COMPLETED.
+  const prevGameStatusRef = useRef(state.gameStatus);
+
+  useEffect(() => {
+    const prevStatus = prevGameStatusRef.current;
+    prevGameStatusRef.current = state.gameStatus;
+
+    if (
+      state.gameStatus === GAME_STATUS.COMPLETED &&
+      prevStatus !== GAME_STATUS.COMPLETED &&
+      isPlayingDailyRef.current &&
+      playingDailyDateRef.current
+    ) {
+      markDailyCompleted(playingDailyDateRef.current);
+      isPlayingDailyRef.current = false;
+      playingDailyDateRef.current = null;
+      // The reducer drives the IDLE→PLAYING→COMPLETED transition; this is
+      // the React-side bookkeeping that mirrors a ref into state so the
+      // StreakBanner can re-render. No cascade — the effect's deps don't
+      // include isPlayingDaily.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsPlayingDaily(false);
+    }
+  }, [state.gameStatus, markDailyCompleted]);
+
+  // Confirm-dismiss guard shared by New Game, Daily, and the two selectors.
+  // The daily CTA uses a fixed message ('confirmNewGame') because the user
+  // is opting INTO a daily, not exiting one — exiting only happens when
+  // the in-progress game IS a daily, which the other three cover.
+  const guardInProgress = useCallback((useDailyCopy: boolean) => {
+    if (
+      (state.gameStatus === GAME_STATUS.PLAYING || state.gameStatus === GAME_STATUS.PAUSED) &&
+      state.historyIndex > 0
+    ) {
+      const key = useDailyCopy && isPlayingDailyRef.current
+        ? 'game.confirmExitDaily'
+        : 'game.confirmNewGame';
+      return window.confirm(t(key));
+    }
+    return true;
+  }, [state.gameStatus, state.historyIndex, t]);
+
+  const clearDaily = useCallback(() => {
+    isPlayingDailyRef.current = false;
+    playingDailyDateRef.current = null;
+    setIsPlayingDaily(false);
+  }, []);
+
+  const handleNewGame = useCallback(() => {
+    if (!guardInProgress(true)) return;
+    clearDaily();
+    actions.newGame(state.difficulty, state.sudokuType);
+    recordGameStart(state.sudokuType, state.difficulty);
+  }, [guardInProgress, clearDaily, actions, state.difficulty, state.sudokuType]);
+
+  const handleStartDaily = useCallback(() => {
+    if (!guardInProgress(false)) return;
+    isPlayingDailyRef.current = true;
+    // Snapshot the puzzle's date NOW so a midnight rollover during play
+    // doesn't change which day completion credits.
+    playingDailyDateRef.current = dailyInfo.date;
+    setIsPlayingDaily(true);
+    actions.newGame(dailyInfo.difficulty, dailyInfo.type, dailyInfo.seed);
+    recordGameStart(dailyInfo.type, dailyInfo.difficulty);
+  }, [guardInProgress, dailyInfo, actions]);
+
+  const handleDifficultyChange = useCallback(
+    (difficulty?: DifficultyLevel) => {
+      if (!guardInProgress(true)) return;
+      clearDaily();
+      actions.newGame(difficulty, state.sudokuType);
+      if (difficulty) recordGameStart(state.sudokuType, difficulty);
+    },
+    [guardInProgress, clearDaily, actions, state.sudokuType],
+  );
+
+  const handleTypeChange = useCallback(
+    (sudokuType?: SudokuTypeId) => {
+      if (!guardInProgress(true)) return;
+      clearDaily();
+      actions.newGame(state.difficulty, sudokuType);
+      if (sudokuType) {
+        recordGameStart(sudokuType, state.difficulty);
+        triggerAutoShow(sudokuType);
+      }
+    },
+    [guardInProgress, clearDaily, actions, state.difficulty, triggerAutoShow],
+  );
+
+  return {
+    isPlayingDaily,
+    handleNewGame,
+    handleStartDaily,
+    handleDifficultyChange,
+    handleTypeChange,
+  };
+}

--- a/src/hooks/usePuzzleLifecycle.ts
+++ b/src/hooks/usePuzzleLifecycle.ts
@@ -76,6 +76,12 @@ export function usePuzzleLifecycle({
       // the React-side bookkeeping that mirrors a ref into state so the
       // StreakBanner can re-render. No cascade — the effect's deps don't
       // include isPlayingDaily.
+      //
+      // The disable below IS load-bearing: `react-hooks/set-state-in-effect`
+      // is a real rule from `eslint-plugin-react-hooks` v7 (it ships ~30
+      // rules, not just `rules-of-hooks` + `exhaustive-deps`), enabled at
+      // error level by `flat.recommended` which our `eslint.config.js`
+      // extends. Remove this line and CI fails. Do not delete.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsPlayingDaily(false);
     }


### PR DESCRIPTION
## Summary

Final slice of #116. Moves the four "start a new puzzle" callbacks (`handleNewGame`, `handleStartDaily`, `handleDifficultyChange`, `handleTypeChange`) plus their shared confirm-guard, the `isPlayingDaily` state + refs, and the daily-completion side effect into `usePuzzleLifecycle`.

**GameContainer drops from 635 → 573 LOC (−62)**. The completion effect that stays in GameContainer now only handles best-time / stats / sound / haptic — the daily branch is owned by the hook.

## What moved into the hook

- **State + refs**: `isPlayingDaily` (state, consumed by `<StreakBanner isPlayingDaily />`), `isPlayingDailyRef`, `playingDailyDateRef`.
- **Shared guard**: `guardInProgress(useDailyCopy)` — single function instead of four copy-pasted `(PLAYING || PAUSED) && historyIndex > 0 && !window.confirm(...)` blocks. Picks the right confirm copy (`confirmExitDaily` when daily is in flight, `confirmNewGame` otherwise; `handleStartDaily` always uses `confirmNewGame` because the user is opting INTO a daily, not exiting one).
- **Shared cleanup**: `clearDaily()` resets the two refs + state in one place.
- **Daily-completion effect**: detects the COMPLETED transition via `prevGameStatusRef`; if a daily is in flight, calls `markDailyCompleted(playingDailyDateRef.current)` with the snapshotted start-date (DST/midnight-safe per #147) and clears the flag.
- **All four callbacks**: identical behavior to before — `recordGameStart` event, `actions.newGame(...)`, `triggerAutoShow(sudokuType)` for type change.

## What stayed in GameContainer

The completion effect's non-daily concerns: `updateBestTime`, `recordGameComplete`, `playVictorySound`, `vibrateComplete`, plus the digit/error sound + haptic routing for non-completion ticks. Those are tangled with the sound effect setup and are a different cleanup.

## Tests

10 new tests in `usePuzzleLifecycle.test.ts`:

- initial `isPlayingDaily` false
- `handleStartDaily` flips state, calls `newGame(diff, type, seed)`, records start
- `handleNewGame` short-circuits on dismissed confirm
- guard fires for PAUSED state too (regression coverage for the original PR #149 finding)
- guard does NOT fire when `historyIndex === 0`
- `handleNewGame` after a daily uses `confirmExitDaily` copy
- `handleStartDaily` always uses `confirmNewGame` copy (never `confirmExitDaily`)
- `handleTypeChange` fires `triggerAutoShow` for the new type
- daily completion: gameStatus → COMPLETED routes to `markDailyCompleted(snapshottedDate)` and clears `isPlayingDaily`
- non-daily completion does NOT call `markDailyCompleted`

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean (one targeted `// eslint-disable-next-line react-hooks/set-state-in-effect` on the daily-completion effect's `setIsPlayingDaily(false)` — same precedent as `OnboardingTour.tsx:76`; the setState mirrors a ref to drive a child re-render, no cascade because the effect's deps don't include `isPlayingDaily`)
- [x] Full unit suite green (no regressions across 24 test files)
- [x] 10/10 new `usePuzzleLifecycle` tests pass
- [ ] Manual smoke: start a daily, complete it → banner flips to "Completed ✓"; click New Game mid-daily → "Exit daily?" confirm copy fires; click difficulty/type while in a non-daily → "Start new game?" confirm copy fires.

## Roadmap status

#116 was the GameContainer "gravity well" issue (728 LOC, 22 commits in 14 days). Across four PRs:

- #183 — `useKeyboardShortcuts` (−76 LOC)
- #184 — `useAutoStartIdle` (−8 LOC)
- #185 — `useShare` (−9 LOC)
- this — `usePuzzleLifecycle` (−62 LOC)

Net **−155 LOC** from GameContainer (728 → 573, −21%). The remaining content is layout / JSX / wiring, which is the right place for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)