### PR TITLE
docs: clarify why react-hooks v7 eslint-disable lines are load-bearing

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -93,6 +93,11 @@ export function GameContainer() {
   // (#143). Until React's useEffectEvent stabilizes, mirroring into a
   // ref during render is the documented workaround.
   const elapsedTimeRef = useRef(state.elapsedTime);
+  // The disable below IS load-bearing: `react-hooks/refs` is a real rule
+  // from `eslint-plugin-react-hooks` v7 (the plugin ships ~30 rules, not
+  // just `rules-of-hooks` + `exhaustive-deps`), enabled at error level by
+  // `flat.recommended` which our `eslint.config.js` extends. Remove this
+  // line and CI fails. Do not delete.
   // eslint-disable-next-line react-hooks/refs
   elapsedTimeRef.current = state.elapsedTime;
 

--- a/src/components/UI/OnboardingTour.tsx
+++ b/src/components/UI/OnboardingTour.tsx
@@ -69,12 +69,20 @@ export function OnboardingTour({ onClose }: Props) {
     };
   }, []);
 
-  // Scroll into view and measure only when step changes
+  // Scroll into view and measure only when step changes.
+  //
+  // The disable below IS load-bearing: `react-hooks/set-state-in-effect` is
+  // a real rule from `eslint-plugin-react-hooks` v7 (the plugin ships ~30
+  // rules, not just `rules-of-hooks` + `exhaustive-deps`), enabled at error
+  // level by `flat.recommended` which our `eslint.config.js` extends.
+  // Remove this line and CI fails. The setState here is a valid use — DOM
+  // measurement after the layout pass — not the antipattern the rule
+  // generally warns against. Do not delete.
   useEffect(() => {
     const el = document.querySelector(currentStep.targetSelector);
     if (el) el.scrollIntoView({ behavior: 'instant', block: 'nearest' });
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRect(getTargetRect(currentStep.targetSelector)); // DOM measurement — valid setState-in-effect use
+    setRect(getTargetRect(currentStep.targetSelector));
     nextButtonRef.current?.focus();
   }, [step, currentStep.targetSelector, getTargetRect]);
 


### PR DESCRIPTION
## Summary

Pre-empt a recurring false positive in PR review.

PRs #184 and #186 each had a reviewer pass that claimed the inline `// eslint-disable-next-line react-hooks/refs` / `react-hooks/set-state-in-effect` directives reference rules that "don't exist" in `eslint-plugin-react-hooks` and silently do nothing.

Both claims are wrong. `eslint-plugin-react-hooks` v7 ships ~30 rules — not just `rules-of-hooks` + `exhaustive-deps`. Both `refs` and `set-state-in-effect` are enabled at error level by `flat.recommended`, which our `eslint.config.js` extends. Removing either disable produces a hard CI failure on the exact line.

This PR adds an explicit comment above each disable in the two already-merged files (`GameContainer.tsx`, `OnboardingTour.tsx`) saying:

- the rule IS real
- which plugin version ships it + which config extends it
- that removing the line breaks CI

The disable in `usePuzzleLifecycle.ts` already got the same treatment in PR #186 commit 5bb7c5e.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on both touched files
- No behavior change — comment-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)