### PR TITLE
fix(a11y): expand how-to-play "?" button hit-area to 44×44

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -179,15 +179,35 @@ test.describe('Sudoku Sensei – smoke tests', () => {
     expect(pseudoInsets.bottom).toBe('-10px');
     expect(pseudoInsets.left).toBe('-10px');
 
-    // Functional check: clicking 8px outside the visible circle still
-    // hits the button (proves the halo is interactive, not just visual).
-    // Scroll into view first so the synthesized click lands in viewport,
-    // and target the modal by its specific aria-labelledby (not the
-    // generic [role="dialog"], which OnboardingTour also uses).
+    // Functional check: clicking 8px outside the visible circle on each
+    // of the four sides still hits the button. The computed-style check
+    // above proves the pseudo exists symmetrically; this proves the halo
+    // is genuinely hit-testable on every side (catches a future change
+    // that e.g. adds `pointer-events: none` to the pseudo). Target the
+    // modal by its specific aria-labelledby (not the generic
+    // [role="dialog"], which OnboardingTour also uses).
     await btn.scrollIntoViewIfNeeded();
-    const fresh = await btn.boundingBox();
-    expect(fresh).not.toBeNull();
-    await page.mouse.click(fresh!.x - 8, fresh!.y + fresh!.height / 2);
-    await expect(page.locator('[aria-labelledby="htp-title"]')).toBeVisible({ timeout: 2000 });
+    const dialog = page.locator('[aria-labelledby="htp-title"]');
+    const closeDialog = async () => {
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeHidden({ timeout: 1000 });
+    };
+
+    for (const side of ['left', 'right', 'top', 'bottom'] as const) {
+      const fresh = await btn.boundingBox();
+      expect(fresh).not.toBeNull();
+      const cx = fresh!.x + fresh!.width / 2;
+      const cy = fresh!.y + fresh!.height / 2;
+      const off = 8; // 8px outside the visible 24×24 circle
+      const pt =
+        side === 'left'   ? { x: fresh!.x - off, y: cy } :
+        side === 'right'  ? { x: fresh!.x + fresh!.width + off, y: cy } :
+        side === 'top'    ? { x: cx, y: fresh!.y - off } :
+                            { x: cx, y: fresh!.y + fresh!.height + off };
+
+      await page.mouse.click(pt.x, pt.y);
+      await expect(dialog, `halo click on ${side}`).toBeVisible({ timeout: 2000 });
+      await closeDialog();
+    }
   });
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -153,4 +153,41 @@ test.describe('Sudoku Sensei – smoke tests', () => {
     // Wait for new puzzle to load
     await expect(page.locator('.cell-initial').first()).toBeVisible({ timeout: 10000 });
   });
+
+  test('how-to-play "?" button has a 44×44 touch target', async ({ page }) => {
+    // #126: visible circle stays 24×24 (don't dominate the eyebrow row)
+    // but the click/tap area must meet WCAG AA + iOS HIG 44×44 minimum.
+    // Implemented via a `before:inset-[-10px]` pseudo-element that adds
+    // a 10px transparent halo around the visible circle.
+    const btn = page.locator('[data-testid="how-to-play-button"]');
+    await expect(btn).toBeVisible({ timeout: 5000 });
+
+    // Visible circle layout footprint stays 24×24
+    const visualBox = await btn.boundingBox();
+    expect(visualBox).not.toBeNull();
+    expect(visualBox!.width).toBe(24);
+    expect(visualBox!.height).toBe(24);
+
+    // The pseudo-element must inset -10px on all sides so the effective
+    // click area is 44×44 (24 + 10 + 10).
+    const pseudoInsets = await btn.evaluate((el) => {
+      const cs = getComputedStyle(el, '::before');
+      return { top: cs.top, right: cs.right, bottom: cs.bottom, left: cs.left };
+    });
+    expect(pseudoInsets.top).toBe('-10px');
+    expect(pseudoInsets.right).toBe('-10px');
+    expect(pseudoInsets.bottom).toBe('-10px');
+    expect(pseudoInsets.left).toBe('-10px');
+
+    // Functional check: clicking 8px outside the visible circle still
+    // hits the button (proves the halo is interactive, not just visual).
+    // Scroll into view first so the synthesized click lands in viewport,
+    // and target the modal by its specific aria-labelledby (not the
+    // generic [role="dialog"], which OnboardingTour also uses).
+    await btn.scrollIntoViewIfNeeded();
+    const fresh = await btn.boundingBox();
+    expect(fresh).not.toBeNull();
+    await page.mouse.click(fresh!.x - 8, fresh!.y + fresh!.height / 2);
+    await expect(page.locator('[aria-labelledby="htp-title"]')).toBeVisible({ timeout: 2000 });
+  });
 });

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -398,7 +398,13 @@ export function GameContainer() {
                     title={t('howToPlay.title')}
                     aria-label={t('howToPlay.title')}
                     data-testid="how-to-play-button"
-                    className="w-6 h-6 flex items-center justify-center rounded-full text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-blue-900/40 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                    // 24×24 visible circle + a `before:` pseudo-element that
+                    // expands the hit-area to 44×44 (WCAG AA / iOS HIG
+                    // minimum). Layout footprint stays 24×24 so the eyebrow
+                    // row doesn't grow; only the click/tap target is bigger
+                    // (#126). before:inset-[-10px] = 24+10+10 = 44 in both
+                    // axes.
+                    className="relative w-6 h-6 flex items-center justify-center rounded-full text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-blue-900/40 hover:text-blue-600 dark:hover:text-blue-400 transition-colors before:absolute before:inset-[-10px] before:content-['']"
                   >
                     ?
                   </button>


### PR DESCRIPTION
Closes #126.

## Summary

Touch target on the help (`?`) button next to the type selector was 24×24, below the WCAG AA / iOS HIG / Android Material 44×44 minimum. Mobile users mis-tapped a button whose entire purpose is to surface help — the worst place to fail.

## Approach

Per the issue's recommendation #1 (visual size unchanged + invisible padding):

- Visible circle: stays **24×24** — doesn't dominate the small "Тип:" eyebrow row.
- Hit area: extended to **44×44** via a `before:inset-[-10px]` pseudo-element — transparent halo around the visible circle.
- Layout footprint: zero change. The eyebrow row height stays the same.

Implementation is one line of Tailwind on the existing button: `relative ... before:absolute before:inset-[-10px] before:content-['']`. No JSX restructure, no new wrapper, no negative margins.

## Test plan

New e2e regression test in `smoke.spec.ts`:
- visible bounding box is exactly 24×24
- `::before` computed `top/right/bottom/left` are all `-10px`
- clicking 8px **outside** the visible circle still opens the modal — proves the halo is genuinely interactive, not just visual

Verified locally:
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] all 6 chromium smoke tests pass (5 pre-existing + 1 new)

## Note on issue #122

While verifying this fix on mobile I also checked #122 ("mobile streak banner truncates 'Начните серию'"). That one was already fixed by #181 (hero treatment) — closed separately with screenshots at 320px and 375px in `ru-RU`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)