### PR TITLE
chore: pin TypeScript to ~5.9 (was ^6.0.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "postcss": "^8.5.6",
         "storybook": "^10.2.8",
         "tailwindcss": "^3.4.19",
-        "typescript": "^6.0.2",
+        "typescript": "~5.9.3",
         "vite": "^7.3.1",
         "vitest": "^3.2.4"
       }
@@ -7558,9 +7558,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "postcss": "^8.5.6",
     "storybook": "^10.2.8",
     "tailwindcss": "^3.4.19",
-    "typescript": "^6.0.2",
+    "typescript": "~5.9.3",
     "vite": "^7.3.1",
     "vitest": "^3.2.4"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,19 @@
+// TypeScript is pinned to ~5.9 (not the latest 6.x) deliberately. Two
+// load-bearing reasons:
+//
+//   1. eslint-plugin-react-hooks v7 + @typescript-eslint v8 (our current
+//      versions) only know about TS ^5 AST node types. On TS 6 some
+//      rules throw "Unhandled node type: <kind>" because new TS 6 nodes
+//      aren't enumerated. Until @typescript-eslint v9 ships with TS 6
+//      support, the linter is brittle on TS 6.
+//
+//   2. i18next + react-i18next peer-require typescript ^5; npm warns
+//      "invalid: ^5 from node_modules/i18next" on TS 6.
+//
+// Re-evaluate when @typescript-eslint v9 lands stable (it'll add TS 6
+// AST coverage). Until then: bump within 5.9.x for patch fixes, do not
+// move to 5.10 / 6.x without re-running lint + tests against the full
+// repo. See PR pinning this version for the failing-rule reproduction.
 {
   "compilerOptions": {
     "target": "ES2020",
@@ -22,7 +38,6 @@
     "noUncheckedIndexedAccess": false,
 
     /* Paths */
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
Pins TypeScript to **~5.9** (latest patch within 5.9.x) instead of the previous `^6.0.2`. Two load-bearing reasons spelled out in the new comment block at the top of `tsconfig.json`:

## Why pin

1. **Lint plugin coverage gap.** `@typescript-eslint@8.x` and `eslint-plugin-react-hooks@7.x` don't yet enumerate TS 6's new AST node kinds. Some rules throw at runtime with `Unhandled node type: <kind>` when they encounter a TS 6 node. Reproducible — and what surfaced this whole investigation — when the user reported seeing those errors in their console; tracked down to `consistent-generic-constructors.js` in `@typescript-eslint/eslint-plugin/dist/rules/`. Until `@typescript-eslint@9` ships with TS 6 AST coverage, the linter is brittle on TS 6.

2. **Peer-dep mismatch.** `i18next` and `react-i18next` both peer-require `typescript@^5`. On TS 6 npm explicitly logs `invalid: "^5" from node_modules/i18next, "^5" from node_modules/react-i18next`. The peer warning is a yellow flag that bigger libraries in the ecosystem haven't tested against TS 6 yet — staying on 5.x keeps us inside the tested matrix.

## Range choice

- `~5.9.3` (not `^5.9.3`) so a future automatic upgrade can pull in `5.9.4`/`5.9.5` patches but **cannot** silently move to 5.10 / 6.x. The unblock signal for relaxing this back to `^` (or moving to 6.x) is `@typescript-eslint@9` going stable with TS 6 support — at that point we re-evaluate.

## Other change in this PR

Removed `"ignoreDeprecations": "6.0"` from `tsconfig.json`. That option was added when the repo was on TS 6 to suppress TS 6 deprecation warnings; on 5.9 it's an unknown compiler option and tsc would error on it.

## Verification

| Check | Result |
|---|---|
| `npm install` | warnings gone (peer-dep `invalid: "^5"` from i18next no longer triggers) |
| `npx tsc --noEmit` | clean |
| `npx eslint .` | clean |
| `npx vitest run --config vitest.unit.config.ts` | exit 0 |
| `npx vite build` | succeeds, `index-*.js` 405.49 kB / 123.84 kB gzip |

## Bundle delta

Compared to the TS-6 build right before this change: same source, slightly different transpile output → 405.49 kB raw / 123.84 kB gzip vs. recent TS-6 builds at ~444 kB raw. Drop is modest and incidental — the goal is build-tooling stability, not size.

## What this PR does NOT do

- Doesn't touch any source code. Pure tooling pin.
- Doesn't bump `@typescript-eslint` (already on 8.58, which is the latest stable that supports TS 5).
- Doesn't try to be clever with downgrade lockstep — npm install handled the dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)