### PR TITLE
ci: enable native auto-merge for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,7 +16,10 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
+  # Least-privilege: gh pr merge --auto only flips the auto-merge flag
+  # (a PR metadata operation), never moves refs. pull-requests: write
+  # is sufficient; contents: write would be needed only if we performed
+  # the merge ourselves.
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+# Enables GitHub's native auto-merge queue on every dependabot PR. The
+# workflow does NOT approve — the human still clicks "Approve" when
+# they're ready. Once approved + CI green + branch up-to-date, GitHub
+# squash-merges automatically.
+#
+# Why pull_request_target: dependabot PRs run with read-only secrets
+# under the regular `pull_request` trigger, so `gh pr merge --auto` can't
+# write. `pull_request_target` runs in the context of the BASE repo
+# (writable secrets) which is what we need. Safe here because we never
+# check out PR head code — we only call the gh CLI against PR metadata.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a tiny workflow that calls \`gh pr merge --auto --squash\` on every dependabot PR. Combined with the auto-merge + strict branch protection settings just flipped on the repo, this gives the desired flow:

\`\`\`
dependabot opens PR
   ↓
workflow auto-enables "auto-merge (squash)"   ← this PR
   ↓
human reviews + clicks Approve                ← still manual
   ↓
auto-merge waits for:
   - CI green (build/lint/typecheck/unit-tests/e2e × 3)
   - branch up-to-date with dev (strict)
   ↓
all green → GitHub squash-merges, deletes branch
\`\`\`

If any gate is red, the PR sits indefinitely. Human re-rebase / re-push / re-CI-run resolves it.

## Why \`pull_request_target\`

Dependabot PRs run with a read-only \`GITHUB_TOKEN\` under the regular \`pull_request\` trigger, so \`gh pr merge --auto\` can't actually call the API. \`pull_request_target\` runs in the context of the base repo with writable secrets.

Safe here because **the workflow never checks out PR head code** — it only invokes the gh CLI against PR metadata. The risk pattern \`pull_request_target\` is usually flagged for is "checkout + run untrusted code with elevated perms", which we don't do.

## Why no auto-approve

The user explicitly wants to be in the approval loop ("я делаю PR approve"). This workflow only enables auto-merge; the human approval gate remains manual. So even patch updates wait for a human click before merging — no risk of bot-approval drift.

## Test plan

- [x] Workflow YAML lints clean (no \`act\` available locally; verified syntactically)
- [ ] Smoke after merge: trigger \`@dependabot rebase\` on one of the open dependabot PRs (#153 etc.); confirm the new workflow fires and "auto-merge (squash)" toggles on in the PR UI
- [ ] After approval: confirm the PR squash-merges itself once CI lands

## Note on the 7 existing dependabot PRs

The workflow only fires on **new** PR events. The 7 currently open dependabot PRs (#153–156, #159, #161, #162) won't auto-enable on their own. After this lands I'll trigger \`@dependabot rebase\` on each — that produces a sync event which the workflow picks up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)