### PR TITLE
chore: make dependabot rebase-strategy: auto explicit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # `auto` is the documented default but we make it explicit so the
+    # intent doesn't drift if dependabot ever changes defaults. Combined
+    # with strict branch protection (require branches up-to-date),
+    # this lets dependabot rebase its own PRs when dev advances —
+    # without us hand-typing `@dependabot rebase` after every merge.
+    rebase-strategy: auto
     groups:
       minor-and-patch:
         update-types:
@@ -29,3 +35,4 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    rebase-strategy: auto


### PR DESCRIPTION
Sets \`rebase-strategy: auto\` explicitly on both dependabot ecosystems (npm + github-actions). Behaviorally a no-op — \`auto\` is the documented default — but locks the intent in config so a future GitHub default change can't silently turn it off.

## Why now

The new strict branch protection on \`dev\` requires PRs to be up-to-date before merging. Without dependabot auto-rebase, every merge to dev leaves existing dependabot PRs in \`BEHIND\` state, blocking auto-merge until someone manually comments \`@dependabot rebase\`. That's exactly the round-trip we just hit on the 7 dependabot PRs after \`#193\` landed.

Explicit \`auto\` keeps dependabot rebasing on its own.

## Caveat

\`rebase-strategy: auto\` doesn't promise instant rebases. Dependabot still has internal queue + rate-limit behavior — sometimes \`@dependabot rebase\` is faster than waiting. This config sets the right default; the manual command remains for when you don't want to wait.

## Test plan

- [x] YAML lints (validated structure manually)
- [ ] After merge: trigger a base-advance event (merge any small PR to dev), watch the existing dependabot PRs auto-rebase within ~10 min without a hand-typed \`@dependabot rebase\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)