### PR TITLE
ci: auto-update open PR branches when dev advances

### DIFF
--- a/.github/workflows/pr-update-branch.yml
+++ b/.github/workflows/pr-update-branch.yml
@@ -1,0 +1,47 @@
+name: Auto-update PR branches
+
+# When dev advances, every open PR targeting dev becomes "behind base".
+# Strict branch protection (require branches up-to-date) blocks merges
+# until each PR is rebased manually. This workflow does the rebase
+# automatically, so PRs cascade-merge after one click of Approve +
+# Enable auto-merge.
+#
+# What it replaces: the "Update branch" button in the GitHub PR UI,
+# applied to every open PR.
+#
+# Trigger is `push` to dev (NOT `pull_request_target`) so the workflow
+# runs in the base-repo context with a normal GITHUB_TOKEN — no
+# dependabot-context permission restrictions like #193 hit.
+#
+# `update-branch` invokes the GraphQL `updatePullRequestBranch` mutation
+# (--rebase mode = clean linear history during dev; final history is
+# squashed regardless when the PR merges, so rebase vs merge here only
+# affects intermediate state).
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Update each open PR targeting dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # `gh pr update-branch` is idempotent: no-op when already up
+          # to date, exits non-zero only on a true failure (conflict,
+          # permission, missing PR). We swallow the exit so one bad PR
+          # doesn't break the loop for the others.
+          for pr in $(gh pr list --base dev --state open --json number --jq '.[].number'); do
+            echo "→ updating PR #$pr"
+            gh pr update-branch "$pr" --rebase || echo "  (skipped: not updatable)"
+          done


### PR DESCRIPTION
Adds \`.github/workflows/pr-update-branch.yml\` — runs on every push to dev, calls \`gh pr update-branch --rebase\` on each open PR targeting dev. Equivalent to clicking "Update branch" in the PR UI, applied automatically to all open PRs.

## Why

Strict branch protection requires up-to-date branches before merging. Each merge to dev pushes every other open PR into \`BEHIND\` state, blocking auto-merge until someone hand-rebases them. We just hit this on the dependabot cascade (#153/155/156 stalled BEHIND after #196 merged) and on PR #197 right now.

## What it replaces

- Manual click of "Update branch" button on every open PR after every dev merge
- For dependabot PRs: dependabot's own \`rebase-strategy: auto\` (which works but lags by minutes)
- For human/Claude PRs: nothing automatic existed before this

## Why \`push\` and not \`pull_request_target\`

The earlier dependabot-automerge workflow (#193, since reverted) tripped on a known GitHub restriction: \`GITHUB_TOKEN\` permissions are read-only when a workflow is triggered by a dependabot PR event, even under \`pull_request_target\`. This workflow triggers on \`push\` to dev — the actor is whoever merged (a human or \`github-actions[bot]\`), NOT dependabot — so the token has full write perms.

## Idempotency + failure isolation

\`gh pr update-branch\` is a no-op when the PR is already up-to-date. The bash loop swallows individual exits (\`|| echo\` after each call), so one PR with a conflict or unusual perms doesn't abort the rest. Conflict cases still surface in the workflow log.

## Test plan

- [x] YAML lints (shellcheck-clean inside the heredoc)
- [ ] After this lands and a subsequent PR merges to dev, confirm:
  - The \`Auto-update PR branches\` workflow run appears in Actions
  - Open PRs that were \`BEHIND\` flip to \`MERGEABLE\` / \`BLOCKED\` (waiting on approval)
  - PR #197 (currently \`BEHIND\` after #196) gets auto-rebased on the next dev merge

## Permission delta

Workflow needs \`contents: write\` (rebase = git push) + \`pull-requests: write\` (read PR list, call updatePullRequestBranch mutation). Both granted at workflow level — repo default stays \`read\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)