### PR TITLE
feat(seo): static prerendering for 28 routes (PR3 of #23)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,12 +28,20 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # Playwright is needed by the prerender step below — it crawls the
+      # built site with a headless Chromium to capture per-route static
+      # HTML. e2e CI installs the browser separately; this job does too.
+      - run: npx playwright install --with-deps chromium
       - run: npx vite build --base /sudoku-cc/
-      # GitHub Pages SPA fallback: any unknown path serves 404.html.
-      # Making 404.html a copy of index.html boots react-router from the
-      # SPA shell and renders the right route. Stopgap until PR3 lands
-      # static prerendering per /{lang}/{slug}; once those exist this 404
-      # only catches truly invalid paths (and Google sees real 404s).
+      # PR3 of #23: prerender each /{lang} and /{lang}/{slug} URL into a
+      # static HTML file under dist/ so GitHub Pages serves crawler-ready
+      # HTML for every variant page on the very first request, no JS
+      # execution required. PRERENDER_BASE matches the deploy base.
+      - run: PRERENDER_BASE=/sudoku-cc/ npm run prerender
+      # GitHub Pages SPA fallback for paths the prerender doesn't cover
+      # (truly invalid URLs, query-string deep links). Static prerender
+      # handles the canonical /{lang}/{slug} set; 404.html catches the
+      # rest by booting the SPA which then redirects via react-router.
       - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/index.html
+++ b/index.html
@@ -8,13 +8,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!--
-      `description` and OG tags moved into React (HomeMeta + LandingMeta)
-      so they're route-aware. React 19 hoists <meta> from anywhere in the
-      tree but does NOT dedupe — leaving a static description here would
-      double up with the per-route variant description on /{lang}/{slug}.
-      Keep <title> as the pre-mount fallback (React 19 DOES dedupe title).
+      No <title> / <meta description> / OG tags here — they're rendered
+      by React (HomeMeta on /{lang}, LandingMeta on /{lang}/{slug}) so
+      they're route-aware. React 19 hoists meta tags from anywhere in
+      the tree but does NOT dedupe against static index.html content;
+      leaving any meta here would double up. Pre-mount state briefly
+      has no title (a ~100ms gap until React mounts) — acceptable
+      tradeoff for the per-route correctness on prerendered HTML
+      (PR3 of #23) and live JS pages alike.
     -->
-    <title>Sudoku Sensei — 13 Variant Puzzles Online</title>
     <meta name="theme-color" content="#7c3aed" />
 
     <!-- Favicon -->

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "prerender": "node scripts/prerender.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,141 @@
+/**
+ * Static prerender for the SEO landing pages (PR3 of #23).
+ *
+ * After `vite build` produces dist/, this script:
+ *   1. Boots Vite's preview server pointed at dist/
+ *   2. Crawls each /{lang} and /{lang}/{slug} URL with headless Chromium
+ *      (Playwright, already a dev dep for e2e)
+ *   3. Captures the fully-rendered HTML AFTER React mounts and writes it
+ *      to dist/{lang}[/{slug}]/index.html
+ *
+ * GitHub Pages serves those static files directly — crawlers (and
+ * humans on slow connections) get fully-formed HTML with the right
+ * <title>, <meta description>, <h1>, canonical, and hreflang on the
+ * very first request, no JS execution required.
+ *
+ * Why a custom script instead of @prerenderer/rollup-plugin: zero new
+ * deps (vite + playwright are both already here), and the surface is
+ * small enough to own outright.
+ *
+ * Slug list is duplicated from src/utils/variantSlugs.ts because
+ * Node-running .mjs can't trivially import .ts. A drift-detection
+ * test in src/utils/variantSlugs.test.ts asserts the two lists match.
+ */
+import { preview } from 'vite';
+import { chromium } from 'playwright';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.join(__dirname, '..', 'dist');
+
+// MUST stay in sync with VARIANT_SLUGS in src/utils/variantSlugs.ts.
+// Drift is caught by the unit test.
+export const VARIANT_SLUGS = [
+  'classic-sudoku',
+  'diagonal-sudoku',
+  'windoku',
+  'anti-knight-sudoku',
+  'odd-even-sudoku',
+  'anti-king-sudoku',
+  'non-consecutive-sudoku',
+  'kropki',
+  'killer-sudoku',
+  'little-killer-sudoku',
+  'greater-than-sudoku',
+  'thermo-sudoku',
+  'sandwich-sudoku',
+];
+export const LANGS = ['en', 'ru'];
+
+export const ROUTES = [
+  ...LANGS.map((l) => `/${l}`),
+  ...LANGS.flatMap((l) => VARIANT_SLUGS.map((s) => `/${l}/${s}`)),
+];
+
+const BASE = process.env.PRERENDER_BASE || '/';
+
+async function prerender() {
+  // Vite preview reads `base` from vite.config.ts unless overridden.
+  // We pass it explicitly so the script works regardless of how the
+  // build was invoked (CLI --base flag doesn't persist into preview).
+  const server = await preview({
+    base: BASE,
+    preview: { port: 4173, strictPort: true },
+  });
+  // server.httpServer is already listening when preview() resolves
+  // (Vite v6+). Capture the actual port in case strictPort is off.
+  const address = server.httpServer.address();
+  const port = typeof address === 'object' && address ? address.port : 4173;
+  const origin = `http://localhost:${port}`;
+  const baseUrl = `${origin}${BASE.replace(/\/$/, '')}`;
+  console.log(`[prerender] preview server at ${baseUrl}`);
+
+  const browser = await chromium.launch();
+  const errors = [];
+  const written = [];
+
+  try {
+    for (const route of ROUTES) {
+      const url = `${baseUrl}${route}`;
+      const ctx = await browser.newContext();
+      // Skip the onboarding tour overlay so it doesn't end up baked
+      // into the static HTML (it'd dim the page for SEO crawlers).
+      await ctx.addInitScript(() => {
+        localStorage.setItem('sudoku-onboarding-done', 'true');
+      });
+      const page = await ctx.newPage();
+      page.on('pageerror', (e) => errors.push(`[${route}] pageerror: ${e.message}`));
+      page.on('console', (m) => {
+        if (m.type() === 'error') errors.push(`[${route}] console.error: ${m.text()}`);
+      });
+
+      await page.goto(url, { waitUntil: 'networkidle', timeout: 30_000 });
+
+      // Wait until the SPA has rendered the meta + game shell:
+      //   - meta description present (LandingMeta or HomeMeta mounted)
+      //   - 81 cells rendered (board generated, even if cells are empty)
+      // This is enough to capture per-route SEO content. Killer-style
+      // variants legitimately have 0 .cell-initial — don't gate on that.
+      await page.waitForFunction(
+        () =>
+          !!document.querySelector('meta[name="description"]') &&
+          document.querySelectorAll('[data-testid="cell"]').length === 81,
+        { timeout: 15_000 },
+      );
+
+      const html = await page.content();
+      const outRel = path.join(route.replace(/^\//, ''), 'index.html');
+      const outPath = path.join(distDir, outRel);
+      await fs.mkdir(path.dirname(outPath), { recursive: true });
+      await fs.writeFile(outPath, html, 'utf-8');
+      written.push(outRel);
+      console.log(`[prerender] wrote ${outRel}`);
+
+      await page.close();
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+    await new Promise((res) => server.httpServer.close(res));
+  }
+
+  if (errors.length) {
+    console.error('\n[prerender] errors during rendering:');
+    for (const e of errors) console.error('  ' + e);
+    process.exit(1);
+  }
+  console.log(`\n[prerender] OK — ${written.length} routes prerendered.`);
+}
+
+// Allow `node scripts/prerender.mjs` to run as a CLI; tests can import
+// the URL list without triggering the crawl.
+const isMainModule =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMainModule) {
+  prerender().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -117,8 +117,13 @@ async function prerender() {
       await ctx.close();
     }
   } finally {
-    await browser.close();
-    await new Promise((res) => server.httpServer.close(res));
+    // Promise.allSettled so if either close throws, the other still runs.
+    // Sequential `await` would leak the preview server if browser.close()
+    // failed first. CI shrugs (process exits anyway), local re-runs care.
+    await Promise.allSettled([
+      browser.close(),
+      new Promise((res) => server.httpServer.close(res)),
+    ]);
   }
 
   if (errors.length) {

--- a/src/utils/variantSlugs.test.ts
+++ b/src/utils/variantSlugs.test.ts
@@ -58,3 +58,21 @@ describe('isSupportedLanguage', () => {
     expect(isSupportedLanguage(undefined)).toBe(false);
   });
 });
+
+describe('drift between variantSlugs.ts and scripts/prerender.mjs', () => {
+  it('VARIANT_SLUGS values match the prerender script\'s hardcoded list', async () => {
+    // The prerender script duplicates the slug list because Node-running
+    // .mjs can't import .ts. This test fails if the two ever diverge —
+    // adding a slug here without updating the .mjs would silently miss
+    // that page in the production prerender.
+    // .mjs has no .d.ts; this import is for runtime drift detection,
+    // not for type-checking the prerender script.
+    const mod = (await import(
+      // @ts-expect-error — no type declarations for the .mjs script
+      '../../scripts/prerender.mjs'
+    )) as { VARIANT_SLUGS: string[]; LANGS: string[] };
+    const { VARIANT_SLUGS: PRERENDER_SLUGS, LANGS: PRERENDER_LANGS } = mod;
+    expect([...PRERENDER_SLUGS].sort()).toEqual([...Object.values(VARIANT_SLUGS)].sort());
+    expect([...PRERENDER_LANGS].sort()).toEqual([...SUPPORTED_LANGUAGES].sort());
+  });
+});


### PR DESCRIPTION
Third slice of #23. After \`vite build\` produces the SPA bundle, a Node script boots Vite's preview server programmatically, walks each \`/{lang}\` and \`/{lang}/{slug}\` URL with headless Chromium (Playwright, already a dev dep), and captures the fully-rendered HTML to \`dist/{lang}[/{slug}]/index.html\`. GitHub Pages serves those files directly.

## What this unlocks

- **Crawlers see fully-formed HTML** on the very first request — title, meta description, canonical, hreflang, OG tags, h1, and the rendered game shell. No JS execution required.
- **Slow connections** get visible content faster (less FOUC). React still hydrates afterwards for interactivity.
- **OG/Twitter scrapers** (which often don't run JS) now get correct social cards from any variant URL.

## Routes (28 total)

\`\`\`
/en                                       (HomeMeta)
/ru                                       (HomeMeta)
/en/{slug}, /ru/{slug} × 13 variants      (LandingMeta)
\`\`\`

\`/\` (root) still serves the SPA shell from \`dist/index.html\` — RootRedirect handles the language pick. \`404.html\` (already wired in #189) keeps catching unknown paths via the SPA shell.

## Implementation

- **\`scripts/prerender.mjs\`**: imports \`vite/preview\` programmatically, launches Chromium, visits each route, waits for \`meta[name="description"]\` + 81 cells (proves React mounted + game generated), captures \`page.content()\`, writes to \`dist/\`. Logs each output, surfaces page errors and console errors as failure conditions, exits 1 if any.
- **\`package.json\`**: adds \`prerender\` script (\`node scripts/prerender.mjs\`).
- **\`.github/workflows/deploy.yml\`**: installs chromium, runs vite build, then runs prerender with \`PRERENDER_BASE=/sudoku-cc/\` so the asset URLs in captured HTML match the deploy base path.
- **\`index.html\`**: drops \`<title>\` (React 19 hoists meta from components but does NOT dedupe against static index.html — leaving the title would produce two \`<title>\` elements in the prerendered HTML, and crawlers' first-element-wins rule would pick the wrong one). Pre-mount state briefly has no title (~100ms until React mounts) — acceptable tradeoff.
- **\`src/utils/variantSlugs.test.ts\`**: drift-detection test asserting the .ts \`VARIANT_SLUGS\` and the .mjs hardcoded list stay in sync. Adding a slug to one without the other now fails the unit suite.

## Verification (local)

\`\`\`
$ npx vite build --base /sudoku-cc/   # 446 kB / 137 kB gzip, ~600ms
$ PRERENDER_BASE=/sudoku-cc/ npm run prerender
[prerender] preview server at http://localhost:4173/sudoku-cc
[prerender] wrote en/index.html
[prerender] wrote ru/index.html
[prerender] wrote en/classic-sudoku/index.html
... × 28 ...
[prerender] OK — 28 routes prerendered.

$ grep -c "</title>" dist/en/killer-sudoku/index.html   # 1
$ grep -c "rel=\"canonical\"" dist/en/killer-sudoku/index.html  # 1
$ grep -c "hreflang=" dist/en/killer-sudoku/index.html  # 3 (en + ru + x-default)
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` clean (drift test uses \`@ts-expect-error\` for the .mjs import — no .d.ts needed)
- [x] \`eslint .\` clean
- [x] Drift test passes — slug list in .ts and .mjs match
- [x] All 10 chromium e2e tests pass (no regression on existing meta + h1 + redirects)
- [ ] After merge: deploy run completes, then verify \`https://leomo42.github.io/sudoku-cc/en/killer-sudoku\` → \`view-source:\` shows variant-specific title, meta, h1 directly in HTML (not added by JS)

## What this PR does NOT do

- No \`sitemap.xml\` / \`robots.txt\` yet — PR4.
- No per-variant landing copy (intro paragraph, rules block) — PR4 with content.
- No CI gate that says "all 28 prerendered files MUST be present" — script exits 1 on errors which fails the deploy job, that's our gate. A more elaborate verification step is overkill for the route count we have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)