### PR TITLE
feat(seo): generate sitemap.xml + robots.txt at build (PR4 of #23)

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -56,6 +56,19 @@ export const ROUTES = [
 
 const BASE = process.env.PRERENDER_BASE || '/';
 
+// MUST stay in sync with CANONICAL_BASE in src/utils/seoUrls.ts. Drift
+// caught by the unit test (same mechanism as VARIANT_SLUGS).
+export const CANONICAL_BASE = 'https://leomo42.github.io/sudoku-cc';
+
+function canonicalUrl(lang, slug) {
+  return slug ? `${CANONICAL_BASE}/${lang}/${slug}` : `${CANONICAL_BASE}/${lang}`;
+}
+
+/** All hreflang alternates for one path — same set our LandingMeta emits. */
+function hreflangAlternates(slug) {
+  return LANGS.map((lang) => ({ lang, href: canonicalUrl(lang, slug) }));
+}
+
 async function prerender() {
   // Vite preview reads `base` from vite.config.ts unless overridden.
   // We pass it explicitly so the script works regardless of how the
@@ -132,6 +145,78 @@ async function prerender() {
     process.exit(1);
   }
   console.log(`\n[prerender] OK — ${written.length} routes prerendered.`);
+
+  // PR4 of #23 — write sitemap.xml + robots.txt alongside the
+  // prerendered HTML. Same URL list, same canonical base; doing it
+  // here keeps a single source of truth.
+  await writeSitemap();
+  await writeRobots();
+}
+
+/**
+ * Generate sitemap.xml at dist root listing every prerendered URL with
+ * full hreflang alternates (per Google's recommendation for
+ * international sites — each <url> entry lists itself plus every
+ * sibling-language version).
+ *
+ * Uses today's date as <lastmod>. Granular per-page lastmod via git
+ * blame would be more accurate but rarely moves the needle in SE
+ * crawl scheduling for a site this size.
+ */
+async function writeSitemap() {
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const entries = [
+    ...LANGS.map((lang) => ({ lang, slug: undefined, priority: '1.0' })),
+    ...LANGS.flatMap((lang) =>
+      VARIANT_SLUGS.map((slug) => ({ lang, slug, priority: '0.8' })),
+    ),
+  ];
+
+  const urlBlocks = entries.map(({ lang, slug, priority }) => {
+    const loc = canonicalUrl(lang, slug);
+    const alts = hreflangAlternates(slug);
+    const altLinks = alts
+      .map(
+        (a) =>
+          `    <xhtml:link rel="alternate" hreflang="${a.lang}" href="${a.href}"/>`,
+      )
+      .join('\n');
+    const xDefault = canonicalUrl('en', slug);
+    return `  <url>
+    <loc>${loc}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>${priority}</priority>
+${altLinks}
+    <xhtml:link rel="alternate" hreflang="x-default" href="${xDefault}"/>
+  </url>`;
+  });
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+${urlBlocks.join('\n')}
+</urlset>
+`;
+  const outPath = path.join(distDir, 'sitemap.xml');
+  await fs.writeFile(outPath, xml, 'utf-8');
+  console.log(`[prerender] wrote sitemap.xml (${entries.length} URLs)`);
+}
+
+/**
+ * Static robots.txt — `Allow: /` for everything, plus a Sitemap:
+ * pointer at the absolute URL so crawlers fetch it without a
+ * separate Search Console submission.
+ */
+async function writeRobots() {
+  const txt = `User-agent: *
+Allow: /
+
+Sitemap: ${CANONICAL_BASE}/sitemap.xml
+`;
+  const outPath = path.join(distDir, 'robots.txt');
+  await fs.writeFile(outPath, txt, 'utf-8');
+  console.log(`[prerender] wrote robots.txt`);
 }
 
 // Allow `node scripts/prerender.mjs` to run as a CLI; tests can import

--- a/src/utils/seoUrls.test.ts
+++ b/src/utils/seoUrls.test.ts
@@ -35,3 +35,18 @@ describe('hreflangAlternates', () => {
     );
   });
 });
+
+describe('drift between seoUrls.ts and scripts/prerender.mjs', () => {
+  it('CANONICAL_BASE in the prerender script matches the one used here', async () => {
+    // Both produce canonical URLs and they MUST point at the same prod
+    // origin — sitemap.xml entries (from the script) must agree with
+    // the <link rel="canonical"> in rendered HTML (from this code).
+    const mod = (await import(
+      // @ts-expect-error — no type declarations for the .mjs script
+      '../../scripts/prerender.mjs'
+    )) as { CANONICAL_BASE: string };
+    expect(canonicalUrl('en', 'killer-sudoku')).toBe(
+      `${mod.CANONICAL_BASE}/en/killer-sudoku`,
+    );
+  });
+});


### PR DESCRIPTION
Fourth slice of #23 (SEO landing pages). Extends \`scripts/prerender.mjs\` to also write \`sitemap.xml\` and \`robots.txt\` at build time, alongside the 28 prerendered HTML files.

## Output

| File | Content |
|---|---|
| \`dist/sitemap.xml\` | 28 \`<url>\` entries (2 home pages + 26 variants × 2 langs), each with full hreflang alternate set (en + ru + x-default), \`lastmod\`=build-date, \`changefreq=weekly\`, \`priority=1.0\` for home / \`0.8\` for variants |
| \`dist/robots.txt\` | \`Allow: /\` + \`Sitemap:\` pointer at the absolute \`https://leomo42.github.io/sudoku-cc/sitemap.xml\` URL |

Sample sitemap entry:

\`\`\`xml
<url>
  <loc>https://leomo42.github.io/sudoku-cc/en/killer-sudoku</loc>
  <lastmod>2026-05-02</lastmod>
  <changefreq>weekly</changefreq>
  <priority>0.8</priority>
  <xhtml:link rel="alternate" hreflang="en" href="https://leomo42.github.io/sudoku-cc/en/killer-sudoku"/>
  <xhtml:link rel="alternate" hreflang="ru" href="https://leomo42.github.io/sudoku-cc/ru/killer-sudoku"/>
  <xhtml:link rel="alternate" hreflang="x-default" href="https://leomo42.github.io/sudoku-cc/en/killer-sudoku"/>
</url>
\`\`\`

Per Google's recommendation for international sites, every \`<url>\` entry lists ALL hreflang siblings (including itself); matches the \`<link rel="alternate">\` set our \`LandingMeta\` already emits in HTML.

## Single source of truth

The same \`VARIANT_SLUGS\` + \`LANGS\` arrays in \`scripts/prerender.mjs\` drive both the prerender crawl and the sitemap generation. \`CANONICAL_BASE\` (\`https://leomo42.github.io/sudoku-cc\`) is duplicated from \`src/utils/seoUrls.ts\` — Node \`.mjs\` can't trivially import \`.ts\`. Drift between the two is caught by a new test in \`seoUrls.test.ts\` (same pattern as the existing \`VARIANT_SLUGS\` drift test).

## After deploy

Submit \`https://leomo42.github.io/sudoku-cc/sitemap.xml\` to Google Search Console — one-time human action. Bing/Yandex pick it up automatically via the \`Sitemap:\` line in robots.txt.

## Verified locally

\`\`\`
$ npx vite build --base /sudoku-cc/
$ PRERENDER_BASE=/sudoku-cc/ npm run prerender
[prerender] OK — 28 routes prerendered.
[prerender] wrote sitemap.xml (28 URLs)
[prerender] wrote robots.txt
\`\`\`

\`dist/sitemap.xml\` validates as well-formed XML, \`dist/robots.txt\` parses as standard format.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint .\` clean (one pre-existing warning about \`react-hooks/set-state-in-effect\` in \`usePuzzleLifecycle.ts\` — unrelated, surfaced earlier)
- [x] Drift test passes — \`CANONICAL_BASE\` in \`.mjs\` matches the \`.ts\` source
- [x] Local sitemap + robots files produced as expected, 28 URLs
- [ ] After deploy: \`curl https://leomo42.github.io/sudoku-cc/sitemap.xml\` returns valid XML; submit to Search Console

## What this PR does NOT do

- No per-variant landing copy (intro paragraph + rules block above the game) — that's PR5.
- No image sitemap, video sitemap, news sitemap — none apply here.
- No per-page granular \`lastmod\` from git history — uniform build-date is fine for crawl scheduling at this site size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)