### PR TITLE
chore: remove now-stale react-hooks/set-state-in-effect disable

### DIFF
--- a/src/hooks/usePuzzleLifecycle.ts
+++ b/src/hooks/usePuzzleLifecycle.ts
@@ -76,13 +76,6 @@ export function usePuzzleLifecycle({
       // the React-side bookkeeping that mirrors a ref into state so the
       // StreakBanner can re-render. No cascade — the effect's deps don't
       // include isPlayingDaily.
-      //
-      // The disable below IS load-bearing: `react-hooks/set-state-in-effect`
-      // is a real rule from `eslint-plugin-react-hooks` v7 (it ships ~30
-      // rules, not just `rules-of-hooks` + `exhaustive-deps`), enabled at
-      // error level by `flat.recommended` which our `eslint.config.js`
-      // extends. Remove this line and CI fails. Do not delete.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsPlayingDaily(false);
     }
   }, [state.gameStatus, markDailyCompleted]);


### PR DESCRIPTION
\`src/hooks/usePuzzleLifecycle.ts:85\` had a \`react-hooks/set-state-in-effect\` disable that was load-bearing when added (PR #186) but no longer fires after a recent \`eslint-plugin-react-hooks\` update. The directive started reporting \`Unused eslint-disable directive\` as a warning on every lint run since at least PR #200.

Removed the disable + the explanatory comment block (which was specifically about why the disable was load-bearing — irrelevant once it's no longer needed).

## Verified the other v7 disables aren't stale

I checked the two neighboring disables added in the same era:

- \`src/components/UI/OnboardingTour.tsx:84\` — \`react-hooks/set-state-in-effect\` — **still fires** ✓ keep
- \`src/components/Game/GameContainer.tsx:136\` — \`react-hooks/refs\` — **still fires** ✓ keep

Removed both temporarily, ran \`eslint\`, saw 2 errors, restored. So this one stale entry in usePuzzleLifecycle is the only cleanup.

## Why only this one became stale (speculation)

The rule's heuristic likely got better at recognizing transition-guard patterns where the setState mirrors a ref already updated in the same block. Other two cases don't fit that pattern.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint .\` — no warnings (was 1 warning before this PR)
- [x] Existing tests on the daily-completion path still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)