### PR TITLE
ci: add Codex PR review in parallel with Claude

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,10 +18,6 @@ jobs:
       github.event.pull_request.user.login == 'LeoMo42'
     runs-on: ubuntu-latest
     name: Claude Code Review
-    # Hard cap: a typical Claude review on a PR runs in ~30s–5min. 15 minutes
-    # is cheap insurance against a hung action burning Actions minutes up to
-    # GitHub's 6-hour default. Same rationale as codex-pr-review.yml.
-    timeout-minutes: 15
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,6 +18,10 @@ jobs:
       github.event.pull_request.user.login == 'LeoMo42'
     runs-on: ubuntu-latest
     name: Claude Code Review
+    # Hard cap: a typical Claude review on a PR runs in ~30s–5min. 15 minutes
+    # is cheap insurance against a hung action burning Actions minutes up to
+    # GitHub's 6-hour default. Same rationale as codex-pr-review.yml.
+    timeout-minutes: 15
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -156,12 +156,12 @@ jobs:
           PROMPT_EOF
           echo "Prompt bytes: $(wc -c < /tmp/codex-prompt.md)"
 
-      # Third-party action — Dependabot's github-actions ecosystem rule will
-      # propose SHA bumps as new tags land. SHA-pin once a version is stable
-      # to protect OPENAI_API_KEY from a supply-chain attack on the action,
-      # same pattern as anthropics/claude-code-action (see #120).
+      # SHA-pinned (was @v1) — protects OPENAI_API_KEY from a supply-chain
+      # attack on this third-party action. Dependabot's github-actions
+      # ecosystem rule will propose SHA bumps as new tags land. Same pattern
+      # as anthropics/claude-code-action — see #120 for context.
       - name: Run Codex Review
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1  # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: /tmp/codex-prompt.md

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -43,9 +43,13 @@ jobs:
         with:
           node-version: '20'
 
+      # Pinned to a known-good version for reproducibility. Bump manually
+      # (or via Dependabot if codex CLI ends up in package.json) when
+      # validating a new release. Latest at ship time of this workflow:
+      # https://www.npmjs.com/package/@openai/codex
       - name: Install Codex CLI
         run: |
-          npm install -g @openai/codex
+          npm install -g @openai/codex@0.128.0
           codex --version
 
       # Why ChatGPT auth instead of OPENAI_API_KEY:
@@ -207,12 +211,15 @@ jobs:
             cat /tmp/pr.comments
           } > /tmp/codex-input.txt
 
-          # codex exec reads the prompt from argv; pipe via stdin not supported
-          # cleanly across versions, so pass the file content as the prompt arg.
+          # Pipe the prompt via stdin (`-`) instead of as an argv argument.
+          # On Linux the per-arg ARG_MAX is ~128 KB and the total argv+env
+          # budget is ~2 MB; a fat PR diff would silently fail process launch
+          # with E2BIG. Stdin sidesteps the limit entirely.
           codex exec \
             --output-last-message /tmp/codex-review.md \
             -c 'model_reasoning_effort="medium"' \
-            "$(cat /tmp/codex-input.txt)" \
+            - \
+            < /tmp/codex-input.txt \
             > /tmp/codex.stdout 2> /tmp/codex.stderr
           echo "Review bytes: $(wc -c < /tmp/codex-review.md 2>/dev/null || echo 0)"
 

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,0 +1,180 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  codex-review:
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login == 'LeoMo42'
+    runs-on: ubuntu-latest
+    name: Codex Code Review
+
+    steps:
+      - name: Checkout PR merge ref
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+
+      - name: Capture PR diff and prior comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} > /tmp/pr.diff
+          gh pr view ${{ github.event.pull_request.number }} --comments \
+            > /tmp/pr.comments || true
+          echo "Diff bytes: $(wc -c < /tmp/pr.diff)"
+
+      - name: Build Codex prompt
+        run: |
+          cat > /tmp/codex-prompt.md <<'PROMPT_EOF'
+          You are reviewing a PR for Sudoku Sensei, a React 19 + TypeScript + Vite
+          sudoku app with 13 variant types (Classic, Diagonal, Killer, Thermo,
+          Sandwich, Kropki, Anti-Knight, Anti-King, Non-Consecutive, Odd-Even,
+          Greater-than, Little-Killer, Windoku).
+
+          Stack: React 19, TypeScript (strict), Vite 8, Tailwind CSS 4 (migrated
+          from v3 in #200), Vitest 4, Playwright, i18next (ru/en), prerendered
+          to GitHub Pages with 28 SEO-indexable routes.
+
+          You are running in **parallel with a Claude reviewer** on the same PR.
+          Both produce independent reviews. Do your own thinking — do not defer
+          to or echo the other reviewer.
+
+          ## Inputs
+
+          - The PR diff is in `/tmp/pr.diff`. Read it.
+          - Prior PR comments are in `/tmp/pr.comments`. Read them.
+          - The full repo is checked out at the working directory. You may
+            `Read` / `grep` files **touched by the diff** to verify a finding,
+            but stay within the diff scope. Do not audit unchanged code.
+
+          ## Your Task
+
+          Produce a code review of the diff. Then write the **entire review**
+          to `/tmp/codex-review.md` — that file is what gets posted to the PR.
+          Do not run any `gh` commands; the workflow handles posting.
+
+          Do not re-raise issues that prior comments already raised, fixed, or
+          that the author explicitly defended. Do not relitigate accepted
+          approaches.
+
+          ## What to look for (in order of priority)
+
+          - **Game logic correctness**: Sudoku constraints, puzzle uniqueness,
+            variant rules (diagonal, anti-knight, sandwich, killer cages,
+            kropki dots, thermo arrows, etc.), undo/redo consistency, mistake
+            counter logic.
+          - **Real bugs**: crashes, data loss, broken localStorage, race
+            conditions, wrong state transitions, accessibility regressions
+            that break a screen reader.
+          - **Type safety holes** that admit runtime errors (not stylistic widening).
+          - **Performance regressions** with a concrete reproduction (81-cell
+            grid re-render is the bar — speculative "this might be slow"
+            doesn't count).
+          - **Tailwind 4 migration relics**: v3-only utilities like
+            `bg-opacity-*`, `flex-shrink-*`, deprecated arbitrary syntax
+            that may not generate in v4. See https://tailwindcss.com/docs/upgrade-guide.
+
+          ## Falsifiability rule (REQUIRED for Critical / Important)
+
+          Every Critical or Important issue MUST include either:
+          - A concrete input or user action that triggers the bug, OR
+          - A failing test you can describe in one sentence.
+
+          If you cannot produce one, the issue is NOT Critical or Important.
+          Demote it to Suggestions or omit it entirely. "This could theoretically
+          fail if X" without a path to X is not a real issue.
+
+          ## Do NOT flag (skip-list)
+
+          - Defensive guards that duplicate an upstream check — defense-in-depth
+            is fine.
+          - Redundant `title` + `aria-label` on the same element — both are valid.
+          - Type widening with no runtime impact (e.g. `boolean | null` vs
+            `boolean`) unless it actually causes a bug.
+          - Test structure / refactoring preferences (helper extraction, naming,
+            what to assert in which `it` block) when the existing tests pass and
+            cover the behavior.
+          - Code outside the diff. If a file is unchanged, do not review it.
+          - Naming, comment wording, JSDoc presence, file organization preferences.
+          - Vague "consider X" suggestions with no concrete bug behind them.
+          - Style nits already enforced by ESLint / Prettier / Tailwind.
+
+          ## Output format (exact)
+
+          The file `/tmp/codex-review.md` MUST start with this header on its
+          own line, followed by a blank line:
+
+          ```
+          **🤖 Codex Review**
+          ```
+
+          Then the sections:
+
+          - **Summary** — 1–2 sentences on what the PR does.
+          - **Strengths** — 1–3 bullets, only if genuinely notable. Skip if routine.
+          - **Critical** — must fix before merge. Each entry needs the
+            falsifiability evidence above. Most PRs have ZERO. Empty section
+            is normal and good.
+          - **Important** — should fix. Each entry needs the falsifiability
+            evidence above. A great review has **0–2** Important issues, not 5.
+            If your draft has more than 3, cut the weakest ones. Padding hurts
+            signal.
+          - **Suggestions** — optional polish. Cap at 3. These are takes, not asks.
+          - **Testing** — 1–3 things a reviewer should manually verify.
+
+          If after honest analysis you have nothing to flag, write exactly:
+
+          ```
+          **🤖 Codex Review**
+
+          **Summary** — <one sentence on what the PR does>
+
+          No Critical, Important, or Suggestions to flag. Diff looks clean.
+
+          **Testing** — <1–2 things to manually verify>
+          ```
+
+          ## Style
+
+          - Specific: cite `file.tsx:123` line numbers.
+          - Explain WHY (the user-visible or runtime impact), not just WHAT.
+          - Terse. No preamble, no fluff, no restating the diff.
+          - It is correct and good to post a short review. Length is not signal.
+
+          A run that exits without writing `/tmp/codex-review.md` is a failed review.
+          PROMPT_EOF
+          echo "Prompt bytes: $(wc -c < /tmp/codex-prompt.md)"
+
+      # Third-party action — Dependabot's github-actions ecosystem rule will
+      # propose SHA bumps as new tags land. SHA-pin once a version is stable
+      # to protect OPENAI_API_KEY from a supply-chain attack on the action,
+      # same pattern as anthropics/claude-code-action (see #120).
+      - name: Run Codex Review
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: /tmp/codex-prompt.md
+          sandbox: workspace-write
+          safety-strategy: drop-sudo
+
+      - name: Post Codex review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ ! -s /tmp/codex-review.md ]; then
+            echo "::error::Codex did not write /tmp/codex-review.md"
+            exit 1
+          fi
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body-file /tmp/codex-review.md

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -17,6 +17,10 @@ jobs:
       github.event.pull_request.user.login == 'LeoMo42'
     runs-on: ubuntu-latest
     name: Codex Code Review
+    # Hard cap: a typical Codex review on a PR runs in ~30s–5min. 15 minutes
+    # is cheap insurance against a hung action burning Actions minutes and
+    # OpenAI quota up to GitHub's 6-hour default.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout PR merge ref

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Codex Code Review
     # Hard cap: a typical Codex review on a PR runs in ~30s–5min. 15 minutes
-    # is cheap insurance against a hung action burning Actions minutes and
-    # OpenAI quota up to GitHub's 6-hour default.
+    # is cheap insurance against a hung CLI burning Actions minutes up to
+    # GitHub's 6-hour default.
     timeout-minutes: 15
 
     steps:
@@ -37,6 +37,45 @@ jobs:
           gh pr view ${{ github.event.pull_request.number }} --comments \
             > /tmp/pr.comments || true
           echo "Diff bytes: $(wc -c < /tmp/pr.diff)"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install Codex CLI
+        run: |
+          npm install -g @openai/codex
+          codex --version
+
+      # Why ChatGPT auth instead of OPENAI_API_KEY:
+      # - Plus subscription quota is way more generous than Tier-1 API TPM
+      # - $0 marginal cost per review (covered by the $20/mo Plus)
+      # - The OpenAI doc covering this CI/CD recipe lives at
+      #   https://developers.openai.com/codex/auth/ci-cd-auth
+      #
+      # Sessions expire after roughly 8 days. Run scripts/codex-auth-refresh.sh
+      # from a logged-in Mac weekly to re-seed CODEX_AUTH_JSON.
+      - name: Seed Codex auth from secret
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -z "$CODEX_AUTH_JSON" ]; then
+            echo "::error::CODEX_AUTH_JSON secret is empty or not configured. See scripts/codex-auth-refresh.sh."
+            exit 1
+          fi
+          mkdir -p "$HOME/.codex"
+          chmod 700 "$HOME/.codex"
+          printf '%s' "$CODEX_AUTH_JSON" > "$HOME/.codex/auth.json"
+          chmod 600 "$HOME/.codex/auth.json"
+          # Sanity check without leaking secret content
+          if ! command -v jq >/dev/null 2>&1; then sudo apt-get install -y -q jq >/dev/null; fi
+          mode=$(jq -r '.auth_mode // "unknown"' "$HOME/.codex/auth.json")
+          if [ "$mode" != "chatgpt" ]; then
+            echo "::error::auth.json is mode='$mode', expected 'chatgpt'. Re-seed via scripts/codex-auth-refresh.sh."
+            exit 1
+          fi
+          echo "Auth mode: $mode (refresh-token: present)"
 
       - name: Build Codex prompt
         run: |
@@ -56,17 +95,17 @@ jobs:
 
           ## Inputs
 
-          - The PR diff is in `/tmp/pr.diff`. Read it.
-          - Prior PR comments are in `/tmp/pr.comments`. Read them.
+          - The PR diff and any prior PR comments are appended below this prompt
+            under `---PR_DIFF---` and `---PRIOR_PR_COMMENTS---` markers.
           - The full repo is checked out at the working directory. You may
             `Read` / `grep` files **touched by the diff** to verify a finding,
             but stay within the diff scope. Do not audit unchanged code.
 
           ## Your Task
 
-          Produce a code review of the diff. Then write the **entire review**
-          to `/tmp/codex-review.md` — that file is what gets posted to the PR.
-          Do not run any `gh` commands; the workflow handles posting.
+          Produce a code review of the diff. Your **final agent message IS the
+          review** — the workflow captures it via `--output-last-message`. Do
+          NOT run `gh` commands; the workflow handles posting.
 
           Do not re-raise issues that prior comments already raised, fixed, or
           that the author explicitly defended. Do not relitigate accepted
@@ -87,7 +126,7 @@ jobs:
             doesn't count).
           - **Tailwind 4 migration relics**: v3-only utilities like
             `bg-opacity-*`, `flex-shrink-*`, deprecated arbitrary syntax
-            that may not generate in v4. See https://tailwindcss.com/docs/upgrade-guide.
+            that may not generate in v4.
 
           ## Falsifiability rule (REQUIRED for Critical / Important)
 
@@ -116,8 +155,8 @@ jobs:
 
           ## Output format (exact)
 
-          The file `/tmp/codex-review.md` MUST start with this header on its
-          own line, followed by a blank line:
+          Your final message MUST start with this header on its own line,
+          followed by a blank line:
 
           ```
           **🤖 Codex Review**
@@ -137,7 +176,7 @@ jobs:
           - **Suggestions** — optional polish. Cap at 3. These are takes, not asks.
           - **Testing** — 1–3 things a reviewer should manually verify.
 
-          If after honest analysis you have nothing to flag, write exactly:
+          If after honest analysis you have nothing to flag, output exactly:
 
           ```
           **🤖 Codex Review**
@@ -155,29 +194,36 @@ jobs:
           - Explain WHY (the user-visible or runtime impact), not just WHAT.
           - Terse. No preamble, no fluff, no restating the diff.
           - It is correct and good to post a short review. Length is not signal.
-
-          A run that exits without writing `/tmp/codex-review.md` is a failed review.
           PROMPT_EOF
           echo "Prompt bytes: $(wc -c < /tmp/codex-prompt.md)"
 
-      # SHA-pinned (was @v1) — protects OPENAI_API_KEY from a supply-chain
-      # attack on this third-party action. Dependabot's github-actions
-      # ecosystem rule will propose SHA bumps as new tags land. Same pattern
-      # as anthropics/claude-code-action — see #120 for context.
       - name: Run Codex Review
-        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1  # v1
-        with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          prompt-file: /tmp/codex-prompt.md
-          sandbox: workspace-write
-          safety-strategy: drop-sudo
+        run: |
+          {
+            cat /tmp/codex-prompt.md
+            printf '\n\n---PR_DIFF---\n'
+            cat /tmp/pr.diff
+            printf '\n\n---PRIOR_PR_COMMENTS---\n'
+            cat /tmp/pr.comments
+          } > /tmp/codex-input.txt
+
+          # codex exec reads the prompt from argv; pipe via stdin not supported
+          # cleanly across versions, so pass the file content as the prompt arg.
+          codex exec \
+            --output-last-message /tmp/codex-review.md \
+            -c 'model_reasoning_effort="medium"' \
+            "$(cat /tmp/codex-input.txt)" \
+            > /tmp/codex.stdout 2> /tmp/codex.stderr
+          echo "Review bytes: $(wc -c < /tmp/codex-review.md 2>/dev/null || echo 0)"
 
       - name: Post Codex review comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ ! -s /tmp/codex-review.md ]; then
-            echo "::error::Codex did not write /tmp/codex-review.md"
+            echo "::error::Codex did not produce a review (--output-last-message file missing or empty)"
+            echo "--- codex stderr (last 50 lines) ---"
+            tail -50 /tmp/codex.stderr 2>/dev/null || true
             exit 1
           fi
           gh pr comment ${{ github.event.pull_request.number }} \

--- a/scripts/codex-auth-refresh.sh
+++ b/scripts/codex-auth-refresh.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# codex-auth-refresh.sh — sync local ~/.codex/auth.json into the
+# CODEX_AUTH_JSON GitHub repo secret so the Codex PR review workflow
+# keeps using your ChatGPT Plus session instead of a per-token API key.
+#
+# Why this exists:
+#   - Codex CLI on this machine is logged in via `codex login` (Plus auth)
+#   - GitHub Actions cannot do interactive OAuth, so CI uses the same
+#     auth.json file shipped as a GitHub secret
+#   - Sessions expire after roughly 8 days. Re-run this weekly (or
+#     whenever a CI run fails with 401) to refresh the secret.
+#
+# Default behavior: PRINT instructions for the GitHub web UI.
+# Pass --auto to upload via the gh CLI instead.
+#
+# Usage:
+#   scripts/codex-auth-refresh.sh           # print manual instructions
+#   scripts/codex-auth-refresh.sh --auto    # upload via gh CLI
+#   scripts/codex-auth-refresh.sh --check   # validate auth.json, no upload
+
+set -euo pipefail
+
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+AUTH_FILE="$CODEX_HOME/auth.json"
+SECRET_NAME="CODEX_AUTH_JSON"
+MODE="${1:-instructions}"
+
+color_red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
+color_yellow() { printf '\033[0;33m%s\033[0m\n' "$*"; }
+color_green()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+color_dim()    { printf '\033[0;90m%s\033[0m\n' "$*"; }
+
+# 1. auth.json must exist
+if [ ! -f "$AUTH_FILE" ]; then
+  color_red "ERROR: $AUTH_FILE not found"
+  echo "Run 'codex login' first to authenticate via ChatGPT Plus."
+  exit 1
+fi
+
+# 2. Must be ChatGPT auth (not API key)
+auth_mode=$(jq -r '.auth_mode // "unknown"' "$AUTH_FILE")
+if [ "$auth_mode" != "chatgpt" ]; then
+  color_red "ERROR: auth_mode is '$auth_mode', expected 'chatgpt'"
+  echo "API-key auth in this file would defeat the purpose. Run:"
+  echo "  codex logout && codex login"
+  echo "to switch to ChatGPT Plus."
+  exit 1
+fi
+
+# 3. Refresh token must be present
+has_refresh=$(jq -r '(.tokens.refresh_token // "") | length > 0' "$AUTH_FILE")
+if [ "$has_refresh" != "true" ]; then
+  color_red "ERROR: refresh_token is missing from auth.json"
+  echo "Run 'codex logout && codex login' to re-establish auth."
+  exit 1
+fi
+
+# 4. Age check (warn if approaching 8-day expiry)
+last_refresh=$(jq -r '.last_refresh // ""' "$AUTH_FILE")
+if [ -n "$last_refresh" ]; then
+  # macOS / BSD date vs GNU date — try both
+  if last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_refresh" +%s 2>/dev/null); then :;
+  elif last_epoch=$(date -d "$last_refresh" +%s 2>/dev/null); then :;
+  else last_epoch=0; fi
+
+  if [ "$last_epoch" != "0" ]; then
+    now=$(date +%s)
+    age_days=$(( (now - last_epoch) / 86400 ))
+    if [ "$age_days" -gt 6 ]; then
+      color_yellow "⚠️  last_refresh was ~${age_days} days ago (~8d expiry approaching)"
+      echo "   Recommend running 'codex login' first to bump the refresh time"
+      echo "   before uploading. Otherwise the secret may go stale soon."
+      echo
+    else
+      color_dim "last_refresh: ~${age_days} days ago (well within ~8d window)"
+    fi
+  fi
+fi
+
+# 5. Show redacted preview
+echo
+echo "$(color_dim "Local file:") $AUTH_FILE"
+echo "$(color_dim "Size:")       $(wc -c < "$AUTH_FILE" | tr -d ' ') bytes"
+echo "$(color_dim "Preview (tokens redacted):")"
+jq '{
+  auth_mode,
+  last_refresh,
+  tokens: (.tokens | with_entries(.value = "<REDACTED:\(.value | length)chars>"))
+}' "$AUTH_FILE" | sed 's/^/  /'
+echo
+
+if [ "$MODE" = "--check" ]; then
+  color_green "✅ auth.json looks healthy. Re-run without --check to upload."
+  exit 0
+fi
+
+# 6. Determine target repo
+if ! command -v gh >/dev/null 2>&1; then
+  color_red "ERROR: gh CLI not found. Install: brew install gh"
+  exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+  color_red "ERROR: not in a GitHub repo (or gh not authenticated)"
+  echo "cd into the sudoku-cc repo and try again."
+  exit 1
+}
+
+if [ "$MODE" = "--auto" ]; then
+  echo "Target repo: $(color_yellow "$REPO")"
+  echo "Secret name: $(color_yellow "$SECRET_NAME")"
+  read -r -p "Upload? [y/N] " confirm
+  case "$confirm" in
+    y|Y|yes|Yes) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+
+  gh secret set "$SECRET_NAME" --repo "$REPO" --body "$(cat "$AUTH_FILE")"
+  color_green "✅ Secret '$SECRET_NAME' updated in $REPO."
+  echo
+  echo "Verify: open the next PR or push to an existing one. Codex review"
+  echo "should run within ~5 min and post a tagged 🤖 Codex Review comment."
+  exit 0
+fi
+
+# Default: print manual instructions
+cat <<EOF
+$(color_dim "═══════════════════════════════════════════════════════════════")
+Manual upload (default):
+$(color_dim "═══════════════════════════════════════════════════════════════")
+
+1. Open settings page:
+   $(color_yellow "https://github.com/$REPO/settings/secrets/actions")
+
+2. Find $(color_yellow "$SECRET_NAME") in the list.
+   - If it exists: click "Update".
+   - If not: click "New repository secret", name it $(color_yellow "$SECRET_NAME").
+
+3. Paste the contents of $AUTH_FILE as the value.
+
+4. Click "Add secret" / "Update secret".
+
+$(color_dim "─── Quick copy to clipboard ───")
+EOF
+
+if command -v pbcopy >/dev/null 2>&1; then
+  cat "$AUTH_FILE" | pbcopy
+  color_green "✅ Contents of auth.json copied to clipboard (macOS pbcopy)."
+elif command -v xclip >/dev/null 2>&1; then
+  cat "$AUTH_FILE" | xclip -selection clipboard
+  color_green "✅ Contents of auth.json copied to clipboard (Linux xclip)."
+else
+  echo "Run manually:  cat $AUTH_FILE | pbcopy   # or  xclip -selection clipboard"
+fi
+
+echo
+color_dim "Or run with --auto to upload directly via gh CLI:"
+color_dim "  scripts/codex-auth-refresh.sh --auto"
+echo


### PR DESCRIPTION
## Summary

Resurrects the parallel-Codex-reviewer workflow originally drafted in PR #76 (closed in favor of single-reviewer at the time, see #117). The premise still holds: single-model review is single-point-of-failure on calibration. Two independent reviewers from different model families on every PR catches what either misses alone.

This session's research round produced direct evidence: \`/codex challenge\` found **1 CRITICAL + 3 HIGH state-machine bugs** in dev (#215-#218) that Claude's existing review pipeline hadn't surfaced. Cross-model coverage adds real signal.

## How it works

- New \`.github/workflows/codex-pr-review.yml\` runs in parallel with \`claude-pr-review.yml\` on every \`pull_request: opened, synchronize, reopened\` (filtered to non-draft maintainer-authored PRs).
- **Same calibration prompt**: falsifiability rule, identical skip-list, identical output format. Both reviewers play by the same rules — divergence reflects model differences, not prompt differences.
- Each comment is tagged (**🤖 Claude Review** vs **🤖 Codex Review**) so they're distinguishable in PR conversation.
- Workflow generates the review then posts via \`gh pr comment --body-file\`. Separation of concerns.

## Updated since PR #76 draft

- Stack reflects current state: Tailwind 4 (was 3.4), Vite 8, Vitest 4, 13 variants enumerated
- Added v4 migration-relic check to skip-list/focus areas (\`bg-opacity-*\`, \`flex-shrink-*\`, scale renames)
- \`actions/checkout\` bumped v5 → v6 to match claude-pr-review.yml
- Note about SHA-pinning \`openai/codex-action\` once a stable version is identified (per #120 supply-chain protection pattern)

## Calibration loop

Track over the next 5–10 PRs:
- **Convergence** (both flag same thing) → high-confidence findings
- **Codex-only** → things Claude's skip-list might be over-pruning
- **Claude-only** → things Codex's defaults might miss
- **Bugs that ship anyway** → was the issue in either reviewer's blind spot? Adjust the relevant prompt.

After 5–10 PRs, decide: keep both, drop one, or merge into a single synthesized review.

## Setup required (one-time)

- [ ] Add **\`OPENAI_API_KEY\`** as a GitHub repo secret (Settings → Secrets and variables → Actions → New repository secret). Same \`sk-proj-…\` key from \`.env\`; the user is on ChatGPT Plus locally but CI cannot use Plus OAuth, needs API key.

Without the secret the new workflow will fail on the codex-action step. Existing Claude workflow is unaffected.

## Cost

\`~$0.05–0.30\` per PR review depending on diff size. Comfortably below the value of the second opinion.

## Test plan

- [x] Workflow YAML lints
- [ ] Add \`OPENAI_API_KEY\` repo secret
- [ ] Merge this PR
- [ ] Open the next feature PR (e.g. PR #0 from current plan: rAF spinner) and confirm both reviews appear within ~5–10 min
- [ ] Verify each comment has its tagged header
- [ ] Confirm no permission/sandbox errors in the codex workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)