### PR TITLE
ci: restore symmetric timeout-minutes on claude-pr-review.yml

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,6 +18,10 @@ jobs:
       github.event.pull_request.user.login == 'LeoMo42'
     runs-on: ubuntu-latest
     name: Claude Code Review
+    # Hard cap: typical review runs in ~30s–5min. 15 minutes is cheap
+    # insurance against a hung action burning Actions minutes up to
+    # GitHub's 6-hour default. Symmetric with codex-pr-review.yml.
+    timeout-minutes: 15
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary

Adds \`timeout-minutes: 15\` back to \`claude-pr-review.yml\`. Codex side got it during PR #229 review feedback; Claude side was reverted from that PR because \`anthropics/claude-code-action\` validates workflow file content against the default branch and rejected the modified version on its own check.

Now landing as a small standalone PR that will trip the same validation guard once on its own Claude check (expected, ignorable), then merges and unblocks all subsequent PRs.

## Why a guard

Typical review runs in ~30s–5min. 15 minutes is cheap insurance against a hung action burning Actions minutes up to GitHub's 6-hour default. Both review workflows now have identical timeout posture.

## Expected red check on this PR

Claude review workflow validation will fail on this PR because the on-PR-branch \`claude-pr-review.yml\` content does not match dev. This is by design — the action prevents PR authors from modifying their own review workflow.

After merge, dev gets the new content, and subsequent PRs validate cleanly.

## Test plan

- [x] YAML lints, no other workflow changes
- [ ] Merge despite expected red Claude check
- [ ] Verify next PR runs Claude review with 15-min cap (and that no PR has previously hit the 6-hour default in audit logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)