### PR TITLE
fix: Modal backdrop renders 50% opacity, not solid black (#224)

### DIFF
--- a/src/components/UI/Modal.tsx
+++ b/src/components/UI/Modal.tsx
@@ -35,7 +35,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black bg-opacity-50"
+        className="absolute inset-0 bg-black/50"
         onClick={onClose}
       />
 


### PR DESCRIPTION
## Summary

\`bg-opacity-50\` is a Tailwind v3 utility that v4 dropped in favor of the \`bg-{color}/{alpha}\` modifier syntax. Without explicit safelisting the v3 class no longer produces any rule, and the Modal backdrop fell back to the bare \`bg-black\` — fully opaque black across the entire viewport.

Every modal in the app (Settings, How to Play, Game Over, etc.) has been shipping with that broken backdrop since the v3→v4 migration in #200.

## Fix

One-character substitution in \`src/components/UI/Modal.tsx:38\`:

\`\`\`diff
- className="absolute inset-0 bg-black bg-opacity-50"
+ className="absolute inset-0 bg-black/50"
\`\`\`

Verified the built CSS contains:

\`\`\`css
.bg-black\\/50 { background-color: #00000080 }       /* 50% alpha */
.bg-black\\/50 { background-color: color-mix(in oklab, var(--color-black) 50%, transparent) }
\`\`\`

## Scope

Closes #224 (the HIGH part). Two LOW tail items from the same issue are NOT in this PR:
- \`flex-shrink-0\` × 4 places — still valid in v4 via legacy alias, deferred to a small cleanup PR
- \`shadow-sm\` / \`rounded-sm\` scale renames — render slightly differently; need design taste call before changing

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint src/components/UI/Modal.tsx\` clean
- [x] \`vite build --base /sudoku-cc/\` builds in 400ms with the v4 utility correctly generated
- [ ] Open the dev server, click any modal-trigger (Settings gear icon, How-to-Play, etc.), confirm the page behind is visible at 50% darkness rather than fully obscured
- [ ] Verify dark-mode renders the same translucent backdrop (no theme-specific override)

## Surfaced by

/codex review of the v0.0.2.0 release in PR #108 (retrospective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)