### PR TITLE
fix: guard gameStatus transitions on terminal/paused states (#215, #216)

### DIFF
--- a/src/context/GameContext.test.ts
+++ b/src/context/GameContext.test.ts
@@ -113,6 +113,22 @@ describe('gameReducer', () => {
       });
       expect(next.errors.size).toBeGreaterThan(0);
     });
+
+    // Regression #216 — paused games should not be mutable. The UI hides
+    // the number pad while paused, but a stale keyboard handler could
+    // still dispatch SET_CELL_VALUE; the reducer must enforce the guard.
+    it.each([GAME_STATUS.PAUSED, GAME_STATUS.IDLE] as const)(
+      'is a no-op when gameStatus is %s',
+      (status) => {
+        const state = { ...createTestState(), gameStatus: status };
+        const next = gameReducer(state, {
+          type: Actions.SET_CELL_VALUE,
+          payload: { row: 0, col: 0, value: 5 },
+        });
+        expect(next).toBe(state);
+        expect(next.board[0]![0]).toBe(EMPTY_CELL);
+      },
+    );
   });
 
   describe('SELECT_CELL', () => {
@@ -227,6 +243,27 @@ describe('gameReducer', () => {
       const resumed = gameReducer(state, { type: Actions.RESUME_GAME });
       expect(resumed.gameStatus).toBe(GAME_STATUS.PLAYING);
     });
+
+    // Regression #215 — pause/resume must NOT resurrect terminal states.
+    it.each([GAME_STATUS.IDLE, GAME_STATUS.COMPLETED, GAME_STATUS.LOST] as const)(
+      'PAUSE_GAME is a no-op when status is %s',
+      (status) => {
+        const state = { ...createTestState(), gameStatus: status };
+        const result = gameReducer(state, { type: Actions.PAUSE_GAME });
+        expect(result.gameStatus).toBe(status);
+        expect(result).toBe(state);
+      },
+    );
+
+    it.each([GAME_STATUS.IDLE, GAME_STATUS.PLAYING, GAME_STATUS.COMPLETED, GAME_STATUS.LOST] as const)(
+      'RESUME_GAME is a no-op when status is %s',
+      (status) => {
+        const state = { ...createTestState(), gameStatus: status };
+        const result = gameReducer(state, { type: Actions.RESUME_GAME });
+        expect(result.gameStatus).toBe(status);
+        expect(result).toBe(state);
+      },
+    );
   });
 
   describe('UPDATE_TIME', () => {

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -154,12 +154,15 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         mistakeLimit?: number | null;
       };
 
-      // Can't modify initial cells, and once the game is lost or
-      // completed all writes are no-ops.
+      // Can't modify initial cells. Writes are also blocked when the
+      // game isn't actively being PLAYED — initial state (IDLE), paused
+      // state, and terminal LOST / COMPLETED states. Without the PAUSED
+      // guard a stuck-key or stale-shortcut handler can mutate the board
+      // while the user thinks the game is suspended (#216).
       if (state.initialBoard[row]![col] !== EMPTY_CELL) {
         return state;
       }
-      if (state.gameStatus === GAME_STATUS.LOST || state.gameStatus === GAME_STATUS.COMPLETED) {
+      if (state.gameStatus !== GAME_STATUS.PLAYING) {
         return state;
       }
 
@@ -380,6 +383,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     }
 
     case Actions.PAUSE_GAME: {
+      // Only PLAYING → PAUSED is a valid transition. Pausing IDLE,
+      // COMPLETED, or LOST is meaningless and — combined with the
+      // RESUME guard below — would resurrect terminal games (#215).
+      if (state.gameStatus !== GAME_STATUS.PLAYING) {
+        return state;
+      }
       return {
         ...state,
         gameStatus: GAME_STATUS.PAUSED,
@@ -387,6 +396,13 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     }
 
     case Actions.RESUME_GAME: {
+      // Only PAUSED → PLAYING. Without this guard, a stale shortcut /
+      // menu handler dispatched against a COMPLETED or LOST game flips
+      // it back to PLAYING and the user can keep mutating the board
+      // past the mistake limit (#215).
+      if (state.gameStatus !== GAME_STATUS.PAUSED) {
+        return state;
+      }
       return {
         ...state,
         gameStatus: GAME_STATUS.PLAYING,


### PR DESCRIPTION
## Summary

Closes #215 (CRITICAL) and #216 (HIGH) — two related reducer guards in \`GameContext.tsx\` surfaced by \`/codex challenge\` round 2.

### #215 — pause/resume can resurrect terminal game states

\`PAUSE_GAME\` and \`RESUME_GAME\` unconditionally overwrote \`gameStatus\`. A stale handler dispatched against a COMPLETED or LOST game flipped it back to PLAYING — the player could keep mutating the board past the mistake limit and break the scoring contract.

**Fix:** PAUSE_GAME requires PLAYING, RESUME_GAME requires PAUSED. Anything else is a no-op.

### #216 — paused games were still mutable

\`SET_CELL_VALUE\` blocked LOST and COMPLETED but not PAUSED. The UI hides the number pad while paused, but the reducer didn't enforce it — a stale keyboard handler could still mutate the board.

**Fix:** SET_CELL_VALUE requires PLAYING explicitly. Tightening the guard also future-proofs against IDLE-state writes (which were already broken in practice but nothing checked the contract).

## Diff

\`\`\`
src/context/GameContext.test.ts | +37 lines
src/context/GameContext.tsx     | +19 -3 lines
\`\`\`

Total: 56 insertions, 3 deletions across two files.

## Tests

73 reducer tests pass (was 64; +9 regression cases):

- PAUSE_GAME × 3 (IDLE, COMPLETED, LOST) — each asserts no-op + identity equality
- RESUME_GAME × 4 (IDLE, PLAYING, COMPLETED, LOST) — same
- SET_CELL_VALUE × 2 (PAUSED, IDLE) — same

The \`expect(result).toBe(state)\` reference check catches both the gameStatus guard and any accidental \`...state\` copy-paths through the reducer.

## Test plan

- [x] Reducer unit tests pass (73/73)
- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [x] \`vite build\` builds in 306ms
- [ ] Manual: solve a puzzle to COMPLETED state, try keyboard shortcut for pause/resume, confirm the game stays in COMPLETED state
- [ ] Manual: lose all mistakes (LOST state), same as above
- [ ] Manual: pause an active game, try to type a digit via keyboard, confirm board doesn't change

🤖 Generated with [Claude Code](https://claude.com/claude-code)