### PR TITLE
fix: prevent Killer cages from containing duplicate digits (#210)

### DIFF
--- a/src/utils/sudokuGenerator.test.ts
+++ b/src/utils/sudokuGenerator.test.ts
@@ -290,5 +290,52 @@ describe('Sudoku Generator', () => {
         expect(typeof foundValid).toBe('boolean');
       });
     });
+
+    // Regression #210 — cage growth must not produce duplicate digits.
+    // Before the fix, generateKillerCages grew cages by orthogonal
+    // adjacency without checking the underlying solution digits, so a
+    // single cage could legitimately catch the same digit twice (since
+    // the same digit appears 9 times in any 9×9 sudoku solution).
+    // The validator then rejects placements that match the solution,
+    // making the puzzle unsolvable.
+    describe('Killer Sudoku', () => {
+      it('cages should never contain duplicate digits (50 puzzles)', () => {
+        for (let i = 0; i < 50; i++) {
+          const { solution, killerCages } = createPuzzle('MEDIUM', 'KILLER', i);
+          expect(killerCages).not.toBeNull();
+          for (const cage of killerCages!) {
+            const digits = cage.cells.map(({ row, col }) => solution[row]![col]!);
+            const unique = new Set(digits);
+            expect(unique.size).toBe(digits.length);
+          }
+        }
+      });
+
+      it('cages cover all 81 cells exactly once', () => {
+        const { killerCages } = createPuzzle('MEDIUM', 'KILLER', 42);
+        const seen = new Set<string>();
+        let total = 0;
+        for (const cage of killerCages!) {
+          for (const { row, col } of cage.cells) {
+            const key = `${row},${col}`;
+            expect(seen.has(key)).toBe(false);
+            seen.add(key);
+            total++;
+          }
+        }
+        expect(total).toBe(GRID_SIZE * GRID_SIZE);
+      });
+
+      it('cage sums match the sum of solution digits in those cells', () => {
+        const { solution, killerCages } = createPuzzle('MEDIUM', 'KILLER', 7);
+        for (const cage of killerCages!) {
+          const expected = cage.cells.reduce(
+            (s, { row, col }) => s + solution[row]![col]!,
+            0,
+          );
+          expect(cage.sum).toBe(expected);
+        }
+      });
+    });
   });
 });

--- a/src/utils/sudokuGenerator.ts
+++ b/src/utils/sudokuGenerator.ts
@@ -344,20 +344,34 @@ function generateKillerCages(solution: Board): KillerCageInternal[] {
     const targetSize = 2 + Math.floor(_rng() * 4); // 2-5
     const cageCells: CellPosition[] = [{ row: r, col: c }];
     assigned[r][c] = true;
+    // Track digits already inside this cage. Killer rules forbid the
+    // same digit twice in a cage, and the validator (#210) rejects any
+    // placement that would create a duplicate. The earlier generator
+    // grew cages purely by orthogonal adjacency, so a 4-cell cage
+    // straddling box boundaries could easily catch the same digit
+    // twice from the underlying classic solution — making the cage
+    // unsolvable from the moment it shipped.
+    const cageDigits = new Set<number>([solution[r][c]]);
 
     while (cageCells.length < targetSize) {
       const candidates: CellPosition[] = [];
       for (const { row, col } of cageCells) {
         for (const [dr, dc] of [[-1,0],[1,0],[0,-1],[0,1]] as [number, number][]) {
           const nr = row+dr, nc = col+dc;
-          if (nr>=0 && nr<9 && nc>=0 && nc<9 && !assigned[nr][nc])
+          if (
+            nr>=0 && nr<9 && nc>=0 && nc<9 &&
+            !assigned[nr][nc] &&
+            !cageDigits.has(solution[nr][nc])
+          ) {
             candidates.push({ row: nr, col: nc });
+          }
         }
       }
       if (!candidates.length) break;
       const pick = candidates[Math.floor(_rng() * candidates.length)];
       cageCells.push(pick);
       assigned[pick.row][pick.col] = true;
+      cageDigits.add(solution[pick.row][pick.col]);
     }
 
     const sum = cageCells.reduce((s, { row, col }) => s + solution[row][col], 0);


### PR DESCRIPTION
## Summary

Closes #210 — a CRITICAL game-correctness bug on the headline Killer variant, surfaced by \`/codex challenge\` round 1.

## The bug

\`generateKillerCages\` in \`src/utils/sudokuGenerator.ts\` grew cages purely by orthogonal adjacency, checking only that the candidate cell hadn't been assigned to another cage. But the same digit appears 9 times in any 9×9 sudoku solution, and adjacent cells across box boundaries frequently share digits — so a 4-5 cell cage could legitimately catch the same digit twice.

The validator (\`sudokuValidator.ts:264\`) explicitly forbids duplicates within a cage. So when the player tried to place the second occurrence (which the underlying solution required), the move was rejected. **Puzzle unsolvable from the moment it shipped.** Headline variant.

## Repro on dev (pre-fix)

\`\`\`ts
import { createPuzzle } from './sudokuGenerator';
for (let seed = 0; seed < 50; seed++) {
  const { solution, killerCages } = createPuzzle('MEDIUM', 'KILLER', seed);
  for (const cage of killerCages!) {
    const digits = cage.cells.map(({row,col}) => solution[row][col]);
    if (new Set(digits).size !== digits.length) {
      console.log(\`seed \${seed} cage \${cage.id} has duplicate digits\`, digits);
    }
  }
}
\`\`\`

The above prints duplicate-digit cages on a meaningful fraction of seeds.

## Fix

Track digits already in the cage as a \`Set<number>\`, seeded with the bulb cell's digit. Filter neighbor candidates to those whose underlying solution digit isn't already in the cage. If no orthogonal neighbor qualifies, finalize the cage at its current size — the existing \`break\` path already handled the assigned-cells case.

\`\`\`diff
+ const cageDigits = new Set<number>([solution[r][c]]);

  while (cageCells.length < targetSize) {
    const candidates: CellPosition[] = [];
    for (const { row, col } of cageCells) {
      for (const [dr, dc] of ...) {
        const nr = row+dr, nc = col+dc;
-       if (nr>=0 && nr<9 && nc>=0 && nc<9 && !assigned[nr][nc])
+       if (
+         nr>=0 && nr<9 && nc>=0 && nc<9 &&
+         !assigned[nr][nc] &&
+         !cageDigits.has(solution[nr][nc])
+       ) {
          candidates.push({ row: nr, col: nc });
+       }
      }
    }
    if (!candidates.length) break;
    const pick = candidates[Math.floor(_rng() * candidates.length)];
    cageCells.push(pick);
    assigned[pick.row][pick.col] = true;
+   cageDigits.add(solution[pick.row][pick.col]);
  }
\`\`\`

## Side effects

- Cages may now finalize at smaller sizes when adjacent-but-uniquely-digited candidates are exhausted (e.g. a corner cell surrounded by neighbors that already have its digit). Mostly results in size-2 / size-3 cages rather than 5; difficulty texture remains.
- All 81 cells are still covered exactly once (verified by test).

## Tests

\`Sudoku Generator > Special Sudoku Types > Killer Sudoku\` — 3 new regression cases:

1. **50 puzzles, seeds 0-49** — every cage's solution digits are unique. This is the regression check; before this PR the assertion fails on a noticeable fraction of seeds.
2. **Single puzzle** — cages cover all 81 cells exactly once (no leaks introduced by the new filter).
3. **Single puzzle** — \`cage.sum\` still matches the sum of solution digits in those cells (no off-by-one introduced by the digit-tracking).

Total generator tests: 25 (was 22, +3).

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [x] 25/25 generator tests pass
- [x] \`vite build\` builds in 335ms
- [ ] Manual: generate Killer Easy / Medium / Hard / Expert from the in-app variant picker, solve cell by cell, confirm validator never rejects a correct placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)