### PR TITLE
fix: clear activeHint on board mutation + safe-wrap localStorage (#217, #218)

### DIFF
--- a/src/context/GameContext.test.ts
+++ b/src/context/GameContext.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { gameReducer, Actions, isValidSavedState, migrateSavedState } from './GameContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { gameReducer, Actions, isValidSavedState, migrateSavedState, safeSetItem, safeRemoveItem } from './GameContext';
 import { GAME_STATUS, EMPTY_CELL } from '../utils/constants';
 import { copyBoard } from '../utils/sudokuValidator';
 import type { GameState } from '../types/index';
@@ -378,6 +378,69 @@ describe('gameReducer', () => {
       const undone = gameReducer(after, { type: Actions.UNDO });
       expect(undone.notes.get('0,0')?.has(1)).toBe(true);
       expect(undone.notes.get('0,0')?.has(3)).toBe(true);
+    });
+  });
+
+  // Regression #217 — every reducer that mutates the board (or the
+  // candidate grid via notes) must clear activeHint, so a stale hint
+  // can't be applied against a state it was no longer computed against.
+  describe('activeHint clearing on board mutation (#217)', () => {
+    function withActiveHint(): GameState {
+      return {
+        ...createTestState(),
+        // Minimal placement-shaped activeHint. The reducer doesn't
+        // inspect its fields here — it just needs to be non-null so
+        // the assertion has something to clear.
+        activeHint: {
+          technique: 'NAKED_SINGLE',
+          placement: { row: 0, col: 0, value: 5 },
+          eliminations: [],
+          highlightCells: [],
+          message: 'stub',
+        } as never,
+      };
+    }
+
+    it('SET_CELL_VALUE clears activeHint', () => {
+      const state = withActiveHint();
+      const next = gameReducer(state, {
+        type: Actions.SET_CELL_VALUE,
+        payload: { row: 1, col: 1, value: 3 },
+      });
+      expect(next.activeHint).toBeNull();
+    });
+
+    it('UNDO clears activeHint', () => {
+      let state = createTestState();
+      state = gameReducer(state, {
+        type: Actions.SET_CELL_VALUE,
+        payload: { row: 0, col: 0, value: 5 },
+      });
+      // Inject a stale hint AFTER a move was made (so history exists)
+      state = { ...state, activeHint: { technique: 'NAKED_SINGLE', placement: { row: 0, col: 0, value: 5 }, eliminations: [], highlightCells: [], message: 'stub' } as never };
+      const undone = gameReducer(state, { type: Actions.UNDO });
+      expect(undone.activeHint).toBeNull();
+    });
+
+    it('REDO clears activeHint', () => {
+      let state = createTestState();
+      state = gameReducer(state, {
+        type: Actions.SET_CELL_VALUE,
+        payload: { row: 0, col: 0, value: 5 },
+      });
+      state = gameReducer(state, { type: Actions.UNDO });
+      state = { ...state, activeHint: { technique: 'NAKED_SINGLE', placement: { row: 0, col: 0, value: 5 }, eliminations: [], highlightCells: [], message: 'stub' } as never };
+      const redone = gameReducer(state, { type: Actions.REDO });
+      expect(redone.activeHint).toBeNull();
+    });
+
+    it('SET_NOTE clears activeHint', () => {
+      const state = withActiveHint();
+      const next = gameReducer(state, {
+        type: Actions.SET_NOTE,
+        payload: { row: 1, col: 1, number: 3 },
+      });
+      expect(next.activeHint).toBeNull();
     });
   });
 
@@ -840,5 +903,61 @@ describe('migrateSavedState', () => {
     const result = migrateSavedState(data);
     expect(data.version).toBeUndefined();
     expect(result).not.toBe(data);
+  });
+});
+
+// Regression #218 — localStorage helpers must not propagate throws from
+// SecurityError / QuotaExceededError environments (private browsing,
+// blocked-domain policies, full quota). The previous code called
+// localStorage.setItem/getItem/removeItem directly and crashed the
+// provider mount on hostile storage.
+describe('safe localStorage helpers (#218)', () => {
+  function mockThrowingStorage(): Storage {
+    const storage = {
+      length: 0,
+      clear: () => { throw new Error('SecurityError'); },
+      getItem: () => { throw new Error('SecurityError'); },
+      key: () => { throw new Error('SecurityError'); },
+      removeItem: () => { throw new Error('SecurityError'); },
+      setItem: () => { throw new Error('SecurityError'); },
+    } satisfies Storage;
+    return storage;
+  }
+
+  let originalStorage: Storage;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalStorage = window.localStorage;
+    Object.defineProperty(window, 'localStorage', {
+      value: mockThrowingStorage(),
+      configurable: true,
+      writable: true,
+    });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: originalStorage,
+      configurable: true,
+      writable: true,
+    });
+    warnSpy.mockRestore();
+  });
+
+  it('safeSetItem swallows SecurityError instead of crashing the caller', () => {
+    expect(() => safeSetItem('any-key', 'any-value')).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to persist to localStorage:',
+      expect.any(Error),
+    );
+  });
+
+  it('safeRemoveItem swallows SecurityError silently (cleanup path)', () => {
+    expect(() => safeRemoveItem('any-key')).not.toThrow();
+    // safeRemoveItem deliberately does NOT log — it's only called from
+    // already-failing paths where adding more noise hurts signal.
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -209,6 +209,11 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         mistakeCount,
         gameStatus,
         notes: newNotes,
+        // Any board mutation invalidates a previously-computed hint:
+        // its target cell or candidate set may no longer match. Without
+        // this clear, APPLY_HINT could overwrite the user's fresh input
+        // with a stale placement (#217).
+        activeHint: null,
         ...pushHistory(state, newBoard, newNotes),
       };
     }
@@ -321,6 +326,10 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         errors,
         historyIndex: prevIndex,
         gameStatus: state.gameStatus === GAME_STATUS.COMPLETED ? GAME_STATUS.PLAYING : state.gameStatus,
+        // Stale-hint guard (#217). After undo, the activeHint's target
+        // cell may already be filled at the prior snapshot, or the
+        // candidate set the elimination was computed against differs.
+        activeHint: null,
       };
     }
 
@@ -338,6 +347,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         errors,
         historyIndex: nextIndex,
         gameStatus: solved ? GAME_STATUS.COMPLETED : state.gameStatus,
+        // Stale-hint guard (#217), same rationale as UNDO.
+        activeHint: null,
       };
     }
 
@@ -378,6 +389,9 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return {
         ...state,
         notes: newNotes,
+        // Stale-hint guard (#217). Toggling a note mutates the candidate
+        // grid the active hint may have been computed against.
+        activeHint: null,
         ...pushHistory(state, state.board, newNotes),
       };
     }
@@ -466,13 +480,28 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
  */
 function loadInitialState(): GameState {
   if (typeof window === 'undefined') return initialState;
-  const savedState = window.localStorage?.getItem(STORAGE_KEY);
+
+  // Wrap the entire localStorage read in try/catch — getItem/setItem can
+  // throw SecurityError or QuotaExceededError in restricted environments
+  // (private browsing, third-party-cookie blocks, blocked-domain policies,
+  // disabled-storage settings). Optional chaining only handles the
+  // `localStorage === undefined` case, not throws from a present-but-
+  // -unreadable storage. Without this the provider mount crashes the
+  // whole app on hostile/restricted browsers (#218).
+  let savedState: string | null = null;
+  try {
+    savedState = window.localStorage?.getItem(STORAGE_KEY) ?? null;
+  } catch (error) {
+    console.warn('localStorage unavailable, starting fresh:', error);
+    return initialState;
+  }
   if (!savedState) return initialState;
+
   try {
     const parsed = JSON.parse(savedState);
     if (!isValidSavedState(parsed)) {
       console.warn('Saved game data is corrupted, starting fresh');
-      window.localStorage.removeItem(STORAGE_KEY);
+      safeRemoveItem(STORAGE_KEY);
       return initialState;
     }
     const migrated = migrateSavedState(parsed);
@@ -481,8 +510,28 @@ function loadInitialState(): GameState {
     return gameReducer(initialState, { type: Actions.LOAD_STATE, payload: migrated });
   } catch (error) {
     console.warn('Failed to load saved game, starting fresh:', error);
-    window.localStorage.removeItem(STORAGE_KEY);
+    safeRemoveItem(STORAGE_KEY);
     return initialState;
+  }
+}
+
+// Best-effort localStorage helpers. These swallow throws (SecurityError,
+// QuotaExceededError) so a hostile storage environment can't crash the
+// app — the user just doesn't get persistence (#218). Exported so tests
+// can assert the swallow contract directly.
+export function safeSetItem(key: string, value: string): void {
+  try {
+    window.localStorage?.setItem(key, value);
+  } catch (error) {
+    console.warn('Failed to persist to localStorage:', error);
+  }
+}
+
+export function safeRemoveItem(key: string): void {
+  try {
+    window.localStorage?.removeItem(key);
+  } catch {
+    // ignore — already in the failure path, best-effort cleanup
   }
 }
 
@@ -509,9 +558,9 @@ export function GameProvider({ children }: { children: ReactNode }) {
         history: undefined,
         historyIndex: undefined,
       };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(stateToSave));
+      safeSetItem(STORAGE_KEY, JSON.stringify(stateToSave));
     } else if (state.gameStatus === GAME_STATUS.COMPLETED || state.gameStatus === GAME_STATUS.LOST) {
-      localStorage.removeItem(STORAGE_KEY);
+      safeRemoveItem(STORAGE_KEY);
     }
   }, [state]);
 


### PR DESCRIPTION
## Summary

Two GameContext defensive fixes bundled because they share a root cause class — reducer/provider hygiene around state mutation. Surfaced by \`/codex challenge\` round 2.

### #217 — \`APPLY_HINT\` could overwrite fresh user input with a stale placement

\`GET_HINT\` stored \`activeHint\` in state, but \`SET_CELL_VALUE\`, \`UNDO\`, \`REDO\`, and \`SET_NOTE\` didn't clear it. Repro:
1. Request a hint targeting R1C7=7
2. Manually type \`4\` at R1C7
3. Apply hint
4. Cell becomes 7 — your 4 is silently overwritten

Fix: every reducer that mutates the board OR the candidate grid (notes) now sets \`activeHint: null\` in its return shape.

### #218 — provider mount could crash the app on hostile storage

The pre-fix code called \`window.localStorage?.getItem\` directly. The optional chaining only handles \`localStorage === undefined\`; it does NOT handle throws from a present-but-unreadable storage. Browsers throw \`SecurityError\` from \`getItem\` itself in:
- private browsing quota
- third-party-cookie / blocked-domain restrictions
- disabled-storage settings (Brave, Tor)
- corporate proxies that strip storage

The save effect had the same gap on \`setItem\` (e.g. \`QuotaExceededError\` once full).

Fix:
- \`loadInitialState\` wraps the read in try/catch and gracefully returns \`initialState\` on throw
- New \`safeSetItem\` / \`safeRemoveItem\` helpers swallow throws and either log a one-line warn (set) or silently ignore (remove from a cleanup path)
- Save effect uses the helpers

## Tests (+6 → 79 total)

\`describe('activeHint clearing on board mutation (#217)')\`:
- SET_CELL_VALUE clears activeHint
- UNDO clears activeHint
- REDO clears activeHint
- SET_NOTE clears activeHint

\`describe('safe localStorage helpers (#218)')\`:
- \`safeSetItem\` swallows SecurityError and logs a warn
- \`safeRemoveItem\` swallows SecurityError silently (cleanup path — adding noise hurts signal in already-failing flows)

Helpers exported so the swallow-on-throw contract has direct coverage. The mock substitutes \`window.localStorage\` with one whose every method throws.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean (zero warnings)
- [x] 79/79 reducer tests pass
- [x] \`vite build\` builds in 316ms
- [ ] Manual #217: request a hint, manually edit the target cell to a different digit, apply hint, confirm your edit is preserved (or that apply was a no-op)
- [ ] Manual #218: open DevTools → Application → uncheck "Allow" for site cookies/storage, reload, confirm the app boots normally (no white screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)