### PR TITLE
fix: dedupe undo history + charge hints on GET not APPLY (#221, #219)

### DIFF
--- a/src/context/GameContext.test.ts
+++ b/src/context/GameContext.test.ts
@@ -1,8 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.mock is hoisted above imports — find/replace findHintStep with a
+// vi.fn so #219 hint-counter tests can drive both the "hint found" and
+// "hint not found" branches of GET_HINT without standing up a real
+// puzzle. No other test in this file dispatches GET_HINT or APPLY_HINT,
+// so the mock is otherwise inert.
+vi.mock('../utils/hintEngine', () => ({
+  findHintStep: vi.fn(),
+}));
+
+import { findHintStep } from '../utils/hintEngine';
 import { gameReducer, Actions, isValidSavedState, migrateSavedState, safeSetItem, safeRemoveItem } from './GameContext';
 import { GAME_STATUS, EMPTY_CELL } from '../utils/constants';
 import { copyBoard } from '../utils/sudokuValidator';
 import type { GameState } from '../types/index';
+
+const mockedFindHintStep = vi.mocked(findHintStep);
 
 function createTestState(): GameState {
   const board = Array(9).fill(null).map(() => Array(9).fill(EMPTY_CELL));
@@ -129,6 +142,35 @@ describe('gameReducer', () => {
         expect(next.board[0]![0]).toBe(EMPTY_CELL);
       },
     );
+
+    // Regression #221 — same-value placement (tapping the same digit
+    // twice, or Clear on an already-empty cell) must be a no-op so it
+    // doesn't push a redundant history snapshot.
+    it('is a no-op when value === current value (digit twice)', () => {
+      let state = createTestState();
+      state = gameReducer(state, {
+        type: Actions.SET_CELL_VALUE,
+        payload: { row: 0, col: 0, value: 5 },
+      });
+      const historyLengthBefore = state.history.length;
+      const next = gameReducer(state, {
+        type: Actions.SET_CELL_VALUE,
+        payload: { row: 0, col: 0, value: 5 },
+      });
+      expect(next).toBe(state);
+      expect(next.history.length).toBe(historyLengthBefore);
+    });
+
+    it('is a no-op when clearing an already-empty cell', () => {
+      const state = createTestState();
+      const historyLengthBefore = state.history.length;
+      const next = gameReducer(state, {
+        type: Actions.SET_CELL_VALUE,
+        payload: { row: 0, col: 0, value: EMPTY_CELL },
+      });
+      expect(next).toBe(state);
+      expect(next.history.length).toBe(historyLengthBefore);
+    });
   });
 
   describe('SELECT_CELL', () => {
@@ -441,6 +483,65 @@ describe('gameReducer', () => {
         payload: { row: 1, col: 1, number: 3 },
       });
       expect(next.activeHint).toBeNull();
+    });
+  });
+
+  // Regression #219 — hintsUsed must be charged on GET_HINT (when a
+  // hint is actually returned), not deferred until APPLY_HINT. Showing
+  // the target cell + technique IS the costly action; deferring made
+  // it trivial to bypass the per-difficulty hint limit by requesting,
+  // reading, and dismissing.
+  describe('hint counter charging (#219)', () => {
+    const stubHint = {
+      technique: 'NAKED_SINGLE',
+      placement: { row: 0, col: 0, value: 5 },
+      eliminations: [],
+      highlightCells: [{ row: 0, col: 0, role: 'target' as const }],
+      message: 'stub',
+    };
+
+    beforeEach(() => {
+      mockedFindHintStep.mockReset();
+    });
+
+    it('GET_HINT increments hintsUsed when a hint is returned', () => {
+      mockedFindHintStep.mockReturnValue(stubHint as never);
+      const state = createTestState();
+      expect(state.hintsUsed).toBe(0);
+      const next = gameReducer(state, { type: Actions.GET_HINT });
+      expect(next.hintsUsed).toBe(1);
+      expect(next.activeHint).not.toBeNull();
+    });
+
+    it('GET_HINT does NOT increment when no hint is found', () => {
+      mockedFindHintStep.mockReturnValue(null);
+      const state = createTestState();
+      const next = gameReducer(state, { type: Actions.GET_HINT });
+      expect(next).toBe(state);
+      expect(next.hintsUsed).toBe(0);
+    });
+
+    it('GET_HINT does NOT increment when hint limit already reached', () => {
+      mockedFindHintStep.mockReturnValue(stubHint as never);
+      // Difficulty.EASY maxHints is well under 9999; this is a hard cap.
+      const state = { ...createTestState(), hintsUsed: 9999 };
+      const next = gameReducer(state, { type: Actions.GET_HINT });
+      expect(next).toBe(state);
+      expect(next.hintsUsed).toBe(9999);
+      // findHintStep should not even be invoked when over the limit
+      expect(mockedFindHintStep).not.toHaveBeenCalled();
+    });
+
+    it('APPLY_HINT does NOT re-charge hintsUsed (already charged at GET_HINT)', () => {
+      const state: GameState = {
+        ...createTestState(),
+        hintsUsed: 1,
+        activeHint: stubHint as never,
+      };
+      const next = gameReducer(state, { type: Actions.APPLY_HINT });
+      expect(next.hintsUsed).toBe(1);
+      // Sanity: the placement was actually applied
+      expect(next.board[0]![0]).toBe(5);
     });
   });
 

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -167,6 +167,14 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       }
 
       const oldValue = state.board[row]![col];
+      // No-op on same-value placement (#221). Tapping the same digit
+      // twice in a cell, or pressing Clear on an already-empty cell,
+      // would otherwise push redundant history snapshots — Undo then
+      // requires multiple presses to revert what felt like one move,
+      // and history grows unbounded under repeated input.
+      if (value === oldValue) {
+        return state;
+      }
       const newBoard = copyBoard(state.board);
       newBoard[row]![col] = value;
 
@@ -259,6 +267,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return {
         ...state,
         activeHint: hintStep,
+        // Charge the hint at GET, not at APPLY (#219). Showing the
+        // target cell + technique IS the costly action — players who
+        // request a hint, read the suggestion, then dismiss without
+        // tapping Apply could otherwise see unlimited free hints by
+        // manually re-creating the move themselves.
+        hintsUsed: state.hintsUsed + 1,
         selectedCell: targetCell
           ? { row: targetCell.row, col: targetCell.col }
           : state.selectedCell,
@@ -298,7 +312,9 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         ...state,
         board: newBoard,
         notes: newNotes,
-        hintsUsed: state.hintsUsed + 1,
+        // hintsUsed is NOT incremented here — it was already charged
+        // at GET_HINT time (#219). Applying is free once the hint has
+        // been revealed.
         errors,
         gameStatus: solved ? GAME_STATUS.COMPLETED : state.gameStatus,
         activeHint: null,


### PR DESCRIPTION
## Summary

Two GameContext scoring/history hygiene fixes from \`/codex challenge\` round 2.

### #221 — undo history records redundant entries for no-op moves

\`SET_CELL_VALUE\` pushed a history snapshot on every dispatch, including no-op placements. Repro:
1. Tap \`5\` in a cell that already shows 5 → history entry created
2. Press Clear on an already-empty cell → history entry created
3. Press Undo → state doesn't visibly change (because the snapshot is identical), then second Undo to actually revert

Plus history grew unbounded under repeated input. Combined with the autosave-every-tick effect, this amplifies localStorage write cost.

**Fix:** early return on \`value === oldValue\` after the initial-cell and PLAYING-status guards.

### #219 — hint counter bypass

\`APPLY_HINT\` incremented \`hintsUsed\`, but \`GET_HINT\` didn't. So a player could trivially bypass the per-difficulty hint cap:
1. Request hint → see target cell + technique (free)
2. Dismiss without applying
3. Manually re-create the move
4. Request another hint (still free)

\`hintsUsed\` only ticked on Apply taps, which is the wrong action — the costly part is **revealing** the hint, not applying it.

**Fix:** move the \`+1\` to GET_HINT (only when a hint is actually returned), drop it from APPLY_HINT. Showing the hint IS the costly action.

## Tests (+6 → 85 total)

\`describe('SET_CELL_VALUE')\`:
- is a no-op when value === current value (digit twice) — asserts state identity + history length unchanged
- is a no-op when clearing an already-empty cell — same

\`describe('hint counter charging (#219)')\`:
- GET_HINT increments hintsUsed when a hint is returned
- GET_HINT does NOT increment when no hint found
- GET_HINT does NOT increment when at hint limit (also confirms findHintStep is short-circuited and not invoked)
- APPLY_HINT does NOT re-charge (sanity check that the placement still applies)

For #219 the test mocks \`findHintStep\` via \`vi.mock\` so we can drive both the "hint returned" and "hint not returned" branches deterministically without standing up a real puzzle. No other test in the file dispatches GET_HINT or APPLY_HINT, so the mock is otherwise inert.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean (zero warnings)
- [x] 85/85 reducer tests pass
- [x] \`vite build\` builds in 317ms
- [ ] Manual #221: type the same digit twice in an empty cell, press Undo once, confirm cell becomes empty in one press (was previously requiring two)
- [ ] Manual #219: on Hard difficulty (5 hints), tap Hint button 5 times without applying any. Verify the 6th tap returns no hint (limit reached). Without this fix, all 6+ would succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)