### PR TITLE
fix: preserve currentStreak through clock-back skew (D3)

### DIFF
--- a/src/utils/dailyPuzzle.test.ts
+++ b/src/utils/dailyPuzzle.test.ts
@@ -166,34 +166,88 @@ describe('recordDailyCompletion', () => {
   });
 });
 
-describe('clock-back exploit guard (#142)', () => {
-  it('does NOT inflate streak when clock rolls back', () => {
+describe('clock-skew handling (#142, D3)', () => {
+  it('does NOT inflate currentStreak when clock rolls back', () => {
     // Step 1: user "travels" to tomorrow and completes.
     recordDailyCompletion(new Date(2024, 0, 16));
     expect(loadDailyStore().currentStreak).toBe(1);
     expect(loadDailyStore().lastCompletedDayNumber).toBeGreaterThan(0);
 
     // Step 2: user rolls clock back to today and tries to complete again.
-    // The future-date guard should detect this and reset to a fresh
-    // single-day streak instead of letting the user farm increments.
+    // The future-date guard clamps lastCompletedDayNumber to today and
+    // preserves currentStreak. The user can't farm streak via clock-back
+    // alone because the streak is unchanged (still 1, not 2).
     const store = recordDailyCompletion(new Date(2024, 0, 15));
-    expect(store.currentStreak).toBe(1); // not 2
-    // The stored date is now today (post-rollback), not tomorrow.
+    expect(store.currentStreak).toBe(1); // not 2 — clock-back can't farm
     expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 15)));
   });
 
-  it('preserves bestStreak through a clock-back reset', () => {
+  it('preserves bestStreak when clock rolls back', () => {
     // Build up a real streak first.
     recordDailyCompletion(new Date(2024, 0, 10));
     recordDailyCompletion(new Date(2024, 0, 11));
     recordDailyCompletion(new Date(2024, 0, 12));
     expect(loadDailyStore().bestStreak).toBe(3);
 
-    // Future date.
+    // Skip ahead past the streak's end (drops currentStreak to 1).
     recordDailyCompletion(new Date(2024, 0, 14));
     // Clock-back attempt.
     const store = recordDailyCompletion(new Date(2024, 0, 13));
     expect(store.bestStreak).toBe(3); // not lost
+  });
+
+  // D3 — preserve a real multi-day currentStreak through a clock-skew
+  // event. The previous behavior reset the streak to 1, wiping months
+  // of legitimate play in a single NTP correction. New behavior clamps
+  // the stored day to today and keeps the streak intact.
+  it('preserves a multi-day currentStreak through clock-back (D3)', () => {
+    // Build a 3-day streak ending Jan 12.
+    recordDailyCompletion(new Date(2024, 0, 10));
+    recordDailyCompletion(new Date(2024, 0, 11));
+    recordDailyCompletion(new Date(2024, 0, 12));
+    expect(loadDailyStore().currentStreak).toBe(3);
+
+    // Clock rolls back to Jan 11 (NTP correction, dead RTC, travel).
+    // User opens the app and re-completes the daily on this earlier
+    // wall-clock day. lastCompletedDayNumber (Jan 12) > today (Jan 11)
+    // triggers the future-date branch.
+    const store = recordDailyCompletion(new Date(2024, 0, 11));
+
+    expect(store.currentStreak).toBe(3); // preserved (was reset to 1 pre-D3)
+    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 11)));
+    expect(store.bestStreak).toBe(3);
+  });
+
+  it('extends the preserved streak on the next consecutive solve (D3)', () => {
+    // Build a 3-day streak.
+    recordDailyCompletion(new Date(2024, 0, 10));
+    recordDailyCompletion(new Date(2024, 0, 11));
+    recordDailyCompletion(new Date(2024, 0, 12));
+
+    // Clock-back skew preserves streak at 3.
+    recordDailyCompletion(new Date(2024, 0, 11));
+    expect(loadDailyStore().currentStreak).toBe(3);
+
+    // Next day after the clamp — the streak should extend to 4 because
+    // clamped lastCompleted (Jan 11) is exactly today-1 (Jan 12).
+    const store = recordDailyCompletion(new Date(2024, 0, 12));
+    expect(store.currentStreak).toBe(4);
+    expect(store.bestStreak).toBe(4);
+  });
+
+  it('idempotent on repeated future-date solves (no double-clamp drift)', () => {
+    recordDailyCompletion(new Date(2024, 0, 16));
+
+    // First clamp: Jan 16 → Jan 15. Streak preserved at 1.
+    const first = recordDailyCompletion(new Date(2024, 0, 15));
+    expect(first.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 15)));
+    expect(first.currentStreak).toBe(1);
+
+    // Second call on same Jan 15: idempotent path (lastCompleted ===
+    // today), returns store as-is. No further mutation.
+    const second = recordDailyCompletion(new Date(2024, 0, 15));
+    expect(second.lastCompletedDayNumber).toBe(first.lastCompletedDayNumber);
+    expect(second.currentStreak).toBe(first.currentStreak);
   });
 });
 

--- a/src/utils/dailyPuzzle.test.ts
+++ b/src/utils/dailyPuzzle.test.ts
@@ -171,83 +171,100 @@ describe('clock-skew handling (#142, D3)', () => {
     // Step 1: user "travels" to tomorrow and completes.
     recordDailyCompletion(new Date(2024, 0, 16));
     expect(loadDailyStore().currentStreak).toBe(1);
-    expect(loadDailyStore().lastCompletedDayNumber).toBeGreaterThan(0);
 
     // Step 2: user rolls clock back to today and tries to complete again.
-    // The future-date guard clamps lastCompletedDayNumber to today and
-    // preserves currentStreak. The user can't farm streak via clock-back
-    // alone because the streak is unchanged (still 1, not 2).
+    // Future-date guard returns store unchanged — the future watermark
+    // stays put. Streak is unchanged (still 1, not 2). lastCompleted
+    // stays at the original future day, NOT clamped to today.
     const store = recordDailyCompletion(new Date(2024, 0, 15));
-    expect(store.currentStreak).toBe(1); // not 2 — clock-back can't farm
-    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 15)));
+    expect(store.currentStreak).toBe(1);
+    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 16)));
   });
 
   it('preserves bestStreak when clock rolls back', () => {
-    // Build up a real streak first.
     recordDailyCompletion(new Date(2024, 0, 10));
     recordDailyCompletion(new Date(2024, 0, 11));
     recordDailyCompletion(new Date(2024, 0, 12));
     expect(loadDailyStore().bestStreak).toBe(3);
 
-    // Skip ahead past the streak's end (drops currentStreak to 1).
     recordDailyCompletion(new Date(2024, 0, 14));
-    // Clock-back attempt.
     const store = recordDailyCompletion(new Date(2024, 0, 13));
-    expect(store.bestStreak).toBe(3); // not lost
+    expect(store.bestStreak).toBe(3);
   });
 
-  // D3 — preserve a real multi-day currentStreak through a clock-skew
-  // event. The previous behavior reset the streak to 1, wiping months
-  // of legitimate play in a single NTP correction. New behavior clamps
-  // the stored day to today and keeps the streak intact.
+  // D3 marquee win — preserve a real multi-day currentStreak through a
+  // clock-skew event. Previous v2 reset to 1; the first D3 attempt
+  // clamped lastCompleted backward (which opened a bounce-farming
+  // exploit Codex caught on PR #238 review). Final design: do not
+  // touch the store on the future-date branch. Streak survives via
+  // getDailyStreak's relaxed `last > today` activeness check.
   it('preserves a multi-day currentStreak through clock-back (D3)', () => {
-    // Build a 3-day streak ending Jan 12.
     recordDailyCompletion(new Date(2024, 0, 10));
     recordDailyCompletion(new Date(2024, 0, 11));
     recordDailyCompletion(new Date(2024, 0, 12));
     expect(loadDailyStore().currentStreak).toBe(3);
 
     // Clock rolls back to Jan 11 (NTP correction, dead RTC, travel).
-    // User opens the app and re-completes the daily on this earlier
-    // wall-clock day. lastCompletedDayNumber (Jan 12) > today (Jan 11)
-    // triggers the future-date branch.
+    // recordDailyCompletion on this earlier wall-clock day is a no-op
+    // for the store — lastCompleted stays at the high-water mark.
     const store = recordDailyCompletion(new Date(2024, 0, 11));
 
-    expect(store.currentStreak).toBe(3); // preserved (was reset to 1 pre-D3)
-    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 11)));
+    expect(store.currentStreak).toBe(3);
+    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 12)));
     expect(store.bestStreak).toBe(3);
   });
 
-  it('extends the preserved streak on the next consecutive solve (D3)', () => {
-    // Build a 3-day streak.
+  // Anti-bounce-farming check (Codex PR #238 review). Pre-fix, clamping
+  // back to Jan 11 then advancing to Jan 12 inflated streak from 3→4
+  // even though Jan 12 was already counted. New behavior treats the
+  // Jan 12 re-solve as idempotent because lastCompleted is still 12.
+  it('does NOT inflate streak on bounce: back-then-forward (Codex)', () => {
+    recordDailyCompletion(new Date(2024, 0, 10));
+    recordDailyCompletion(new Date(2024, 0, 11));
+    recordDailyCompletion(new Date(2024, 0, 12));
+    expect(loadDailyStore().currentStreak).toBe(3);
+
+    // Clock back to Jan 11, solve. Future-date no-op. Streak=3.
+    recordDailyCompletion(new Date(2024, 0, 11));
+    expect(loadDailyStore().currentStreak).toBe(3);
+    expect(loadDailyStore().lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 12)));
+
+    // Clock forward to Jan 12, solve again. lastCompleted is still 12,
+    // so today === lastCompleted → idempotent. Streak stays at 3.
+    const store = recordDailyCompletion(new Date(2024, 0, 12));
+    expect(store.currentStreak).toBe(3);
+    expect(store.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 12)));
+  });
+
+  // Honest user happy path: streak survives the skew window AND extends
+  // when the wall clock catches up to the next genuinely-new day.
+  it('extends streak on the next genuinely-new day after a skew episode', () => {
     recordDailyCompletion(new Date(2024, 0, 10));
     recordDailyCompletion(new Date(2024, 0, 11));
     recordDailyCompletion(new Date(2024, 0, 12));
 
-    // Clock-back skew preserves streak at 3.
+    // Clock-back episode — no streak change (no-op).
     recordDailyCompletion(new Date(2024, 0, 11));
     expect(loadDailyStore().currentStreak).toBe(3);
 
-    // Next day after the clamp — the streak should extend to 4 because
-    // clamped lastCompleted (Jan 11) is exactly today-1 (Jan 12).
-    const store = recordDailyCompletion(new Date(2024, 0, 12));
+    // Clock catches up to real Jan 13. lastCompleted is still 12, so
+    // today === lastCompleted+1 → consecutive-day path → streak=4.
+    const store = recordDailyCompletion(new Date(2024, 0, 13));
     expect(store.currentStreak).toBe(4);
     expect(store.bestStreak).toBe(4);
   });
 
-  it('idempotent on repeated future-date solves (no double-clamp drift)', () => {
+  it('repeated future-date solves are no-ops (no drift)', () => {
     recordDailyCompletion(new Date(2024, 0, 16));
+    const before = loadDailyStore();
 
-    // First clamp: Jan 16 → Jan 15. Streak preserved at 1.
     const first = recordDailyCompletion(new Date(2024, 0, 15));
-    expect(first.lastCompletedDayNumber).toBe(toDayNumber(new Date(2024, 0, 15)));
-    expect(first.currentStreak).toBe(1);
+    expect(first.currentStreak).toBe(before.currentStreak);
+    expect(first.lastCompletedDayNumber).toBe(before.lastCompletedDayNumber);
 
-    // Second call on same Jan 15: idempotent path (lastCompleted ===
-    // today), returns store as-is. No further mutation.
-    const second = recordDailyCompletion(new Date(2024, 0, 15));
-    expect(second.lastCompletedDayNumber).toBe(first.lastCompletedDayNumber);
-    expect(second.currentStreak).toBe(first.currentStreak);
+    const second = recordDailyCompletion(new Date(2024, 0, 14));
+    expect(second.currentStreak).toBe(before.currentStreak);
+    expect(second.lastCompletedDayNumber).toBe(before.lastCompletedDayNumber);
   });
 });
 
@@ -271,6 +288,22 @@ describe('getDailyStreak', () => {
     recordDailyCompletion(old);
     const streak = getDailyStreak();
     expect(streak.current).toBe(0);
+    expect(streak.best).toBe(1);
+  });
+
+  // D3 — when stored lastCompleted is in the future relative to wall
+  // clock (clock skewed backward), the streak should still display.
+  // Without this case, an honest NTP correction would silently zero
+  // the displayed streak even though the store kept the value.
+  it('returns current streak when stored last is in the future (clock-back skew)', () => {
+    // Seed a store with lastCompleted set N days ahead of today.
+    const future = new Date();
+    future.setDate(future.getDate() + 5);
+    recordDailyCompletion(future);
+    expect(loadDailyStore().currentStreak).toBe(1);
+
+    const streak = getDailyStreak();
+    expect(streak.current).toBe(1); // would be 0 pre-D3
     expect(streak.best).toBe(1);
   });
 });

--- a/src/utils/dailyPuzzle.ts
+++ b/src/utils/dailyPuzzle.ts
@@ -189,28 +189,26 @@ export function recordDailyCompletion(date = new Date()): DailyStore {
   // "last completed" is in the future relative to the system clock, the
   // user's wall clock skewed forward at some point — NTP correction
   // after a long offline window, dead RTC battery, travel across the
-  // dateline, DST edge case. The previous code punished this with a
-  // full reset of currentStreak (back to 1), which can wipe a months-
-  // long streak from one honest correction.
+  // dateline, DST edge case.
   //
-  // The benign cases dominate. The cheat case (intentionally setting
-  // the clock forward to farm streak days) is bounded: a cheater can
-  // farm at most 1 streak-day per actual puzzle solve, the same rate
-  // as honest play. So preserving currentStreak through clock skews
-  // trades a non-event in the cheat path for a real win in the
-  // legitimate-skew path.
+  // The previous v2 code reset currentStreak to 1 on this branch, which
+  // wiped a months-long streak from one honest correction. The first
+  // D3 implementation clamped lastCompletedDayNumber to today and
+  // preserved currentStreak — but Codex caught (PR #238 review) that
+  // clamp + the consecutive-day extension path opens a bounce-farming
+  // hole: clock back → solve → clock forward (to original day) → solve
+  // bumps the streak again even though no genuinely-new calendar day
+  // was completed.
   //
-  // Clamp lastCompletedDayNumber to today; do NOT extend the streak
-  // (today's completion is implicit in the clamp). Subsequent
-  // consecutive-day solves extend normally.
+  // Final design: do not move lastCompletedDayNumber backward. Treat
+  // the call as a no-op for the store. The streak survives because
+  // getDailyStreak below also accepts last > today as "active". When
+  // the wall clock catches up to or surpasses the stored mark,
+  // recordDailyCompletion resumes normal extension semantics. The
+  // bounce-farming exploit is closed: a cheater swinging clock back
+  // then forward sees idempotent returns, no streak inflation.
   if (store.lastCompletedDayNumber !== null && store.lastCompletedDayNumber > today) {
-    const clamped: DailyStore = {
-      ...store,
-      lastCompletedDayNumber: today,
-      // currentStreak / bestStreak preserved as-is.
-    };
-    saveDailyStore(clamped);
-    return clamped;
+    return store;
   }
 
   // Idempotent: re-recording the same day is a no-op (e.g. user solves the
@@ -238,11 +236,16 @@ export function recordDailyCompletion(date = new Date()): DailyStore {
 export function getDailyStreak(): { current: number; best: number } {
   const store = loadDailyStore();
   const today = toDayNumber(new Date());
-  // A streak is "active" if the last completion was today or yesterday;
-  // otherwise we display 0 (without zeroing the stored value — bestStreak
-  // and the next consecutive completion can still pick it up).
+  // A streak is "active" if the last completion was today, yesterday,
+  // OR in the future (clock-skew episode — see recordDailyCompletion's
+  // future-date guard for full rationale, D3). Without the future-
+  // -date case, an honest NTP correction backward would silently zero
+  // out the displayed streak even though the stored streak survives
+  // — visible regression equivalent to a reset.
   const last = store.lastCompletedDayNumber;
-  const streakActive = last === today || last === today - 1;
+  const streakActive = last !== null && (
+    last === today || last === today - 1 || last > today
+  );
   return {
     current: streakActive ? store.currentStreak : 0,
     best: store.bestStreak,

--- a/src/utils/dailyPuzzle.ts
+++ b/src/utils/dailyPuzzle.ts
@@ -185,20 +185,32 @@ export function recordDailyCompletion(date = new Date()): DailyStore {
   const today = toDayNumber(date);
   const store = loadDailyStore();
 
-  // Future-date guard: if the stored "last completed" is in the future
-  // relative to the system clock, the user has rolled their clock back
-  // (either intentionally to farm streaks, or via NTP / dead RTC battery).
-  // Reset to a fresh single-day streak — neither rewarding the cheat nor
-  // punishing the honest user beyond a one-day streak loss.
+  // Future-date guard (D3 from research-round interview): if the stored
+  // "last completed" is in the future relative to the system clock, the
+  // user's wall clock skewed forward at some point — NTP correction
+  // after a long offline window, dead RTC battery, travel across the
+  // dateline, DST edge case. The previous code punished this with a
+  // full reset of currentStreak (back to 1), which can wipe a months-
+  // long streak from one honest correction.
+  //
+  // The benign cases dominate. The cheat case (intentionally setting
+  // the clock forward to farm streak days) is bounded: a cheater can
+  // farm at most 1 streak-day per actual puzzle solve, the same rate
+  // as honest play. So preserving currentStreak through clock skews
+  // trades a non-event in the cheat path for a real win in the
+  // legitimate-skew path.
+  //
+  // Clamp lastCompletedDayNumber to today; do NOT extend the streak
+  // (today's completion is implicit in the clamp). Subsequent
+  // consecutive-day solves extend normally.
   if (store.lastCompletedDayNumber !== null && store.lastCompletedDayNumber > today) {
-    const reset: DailyStore = {
+    const clamped: DailyStore = {
       ...store,
-      currentStreak: 1,
-      bestStreak: Math.max(store.bestStreak, 1),
       lastCompletedDayNumber: today,
+      // currentStreak / bestStreak preserved as-is.
     };
-    saveDailyStore(reset);
-    return reset;
+    saveDailyStore(clamped);
+    return clamped;
   }
 
   // Idempotent: re-recording the same day is a no-op (e.g. user solves the


### PR DESCRIPTION
## Summary

Implements design decision **D3** from the research-round interview: preserve \`currentStreak\` when the device clock skews relative to the stored watermark, instead of resetting to 1.

## Why

The future-date branch in \`recordDailyCompletion\` fires when stored \`lastCompletedDayNumber\` is greater than today's day number. Real-world causes: NTP correction after a long offline window, dead RTC battery, travel across the dateline, DST edge case.

The previous v2 behavior **reset \`currentStreak\` to 1** in all these cases. A 30-day or 365-day legitimate streak could be wiped by one honest NTP correction.

## Fix (final design after Codex review)

The first attempt clamped \`lastCompletedDayNumber\` to today and preserved \`currentStreak\`. Codex caught (in this PR's review) that clamp + the consecutive-day extension path opened a bounce-farming exploit:

\`\`\`
streak=3 ending Jan 12 (lastCompleted=12)
clock → Jan 11, solve  → clamp lastCompleted=11, streak=3
clock → Jan 12, solve  → today=12, last=11=today-1 → streak=4  ❌
\`\`\`

Each bounce inflated the streak with two re-solves of already-counted days.

**Final design:** do not move \`lastCompletedDayNumber\` backward. The future-date branch is a no-op for the store. The streak survives because \`getDailyStreak\`'s activeness check is relaxed to accept \`last > today\` as 'active' — covers the clock-skew display window without opening the bounce hole.

\`\`\`diff
  if (store.lastCompletedDayNumber !== null && store.lastCompletedDayNumber > today) {
-   const reset: DailyStore = { ...store, currentStreak: 1, ... };
-   saveDailyStore(reset);
-   return reset;
+   return store;
  }
\`\`\`

\`\`\`diff
- const streakActive = last === today || last === today - 1;
+ const streakActive = last !== null && (last === today || last === today - 1 || last > today);
\`\`\`

## Trade-offs

| Scenario | Pre-D3 | First D3 (clamp) | Final (this PR) |
|---|---|---|---|
| Honest NTP correction backward | Reset to 1 ❌ | Preserve ✓ | Preserve ✓ |
| Streak displays during skew window | 0 ❌ | Shows ✓ | Shows ✓ |
| Clock-back-then-forward bounce | (no change) | Inflates streak ❌ | Idempotent ✓ |
| Clock-forward-only farming | Same | Same | Same (bounded by solve rate, pre-existing) |

## Tests (+5 → 37 total)

\`describe('clock-skew handling (#142, D3)')\`:
- existing 'does NOT inflate currentStreak when clock rolls back' — anti-cheat assertion
- existing 'preserves bestStreak when clock rolls back'
- new 'preserves a multi-day currentStreak through clock-back (D3)' — the marquee win
- new 'does NOT inflate streak on bounce: back-then-forward (Codex)' — locks in the closed exploit
- new 'extends streak on the next genuinely-new day after a skew episode' — honest user happy path
- new 'repeated future-date solves are no-ops (no drift)'

\`describe('getDailyStreak')\`:
- new 'returns current streak when stored last is in the future (clock-back skew)' — display works during the skew window

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [x] 37/37 dailyPuzzle tests pass
- [x] \`vite build\` clean
- [ ] Manual: complete a daily, set device clock back 1 day, open the app, confirm streak counter shows correctly. Solve the daily again — streak should NOT increase. Set clock forward to next real day, solve — streak should extend by 1.

## Review trail

- Codex Important finding on bounce-farming: https://github.com/LeoMo42/sudoku-cc/pull/238#issuecomment-4366919642
- Acknowledged + fixed in 13fd78f

🤖 Generated with [Claude Code](https://claude.com/claude-code)