### PR TITLE
fix(seo): variant nav resyncs board, lang attribute mirrors route (#223)

### DIFF
--- a/src/hooks/useAutoStartIdle.test.ts
+++ b/src/hooks/useAutoStartIdle.test.ts
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { useAutoStartIdle } from './useAutoStartIdle';
 import { GAME_STATUS } from '../utils/constants';
 import * as stats from '../utils/stats';
-import type { GameState, GameActions } from '../types/index';
+import type { GameState, GameActions, SudokuTypeId } from '../types/index';
 
 function makeState(overrides: Partial<GameState> = {}): GameState {
   return {
@@ -162,6 +162,56 @@ describe('useAutoStartIdle', () => {
       );
       expect(actions.newGame).not.toHaveBeenCalled();
       expect(recordSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // Regression #223 bug 1 — GameProvider stays mounted as the user
+  // navigates between /{lang}/{slug} routes, so the URL/<title>/landing
+  // copy update but the BOARD stays on the previous variant. The
+  // forcedVariant-change effect closes that gap.
+  describe('forcedVariant change post-mount', () => {
+    it('starts a new game when forcedVariant changes mid-session', () => {
+      const recordSpy = vi.spyOn(stats, 'recordGameStart');
+      const actions = makeActions();
+      const state = makeState({ gameStatus: GAME_STATUS.PLAYING, sudokuType: 'KILLER' });
+      const { rerender } = renderHook(
+        ({ forcedVariant }: { forcedVariant: SudokuTypeId }) =>
+          useAutoStartIdle(state, actions, { forcedVariant }),
+        { initialProps: { forcedVariant: 'KILLER' satisfies SudokuTypeId } },
+      );
+      // Mount: forcedVariant matches state, no auto-start.
+      expect(actions.newGame).not.toHaveBeenCalled();
+      recordSpy.mockClear();
+
+      rerender({ forcedVariant: 'THERMO' });
+      expect(actions.newGame).toHaveBeenCalledWith('EASY', 'THERMO');
+      expect(recordSpy).toHaveBeenCalledWith('THERMO', 'EASY');
+    });
+
+    it('does NOT re-fire on first render', () => {
+      const actions = makeActions();
+      renderHook(() =>
+        useAutoStartIdle(
+          makeState({ gameStatus: GAME_STATUS.PLAYING, sudokuType: 'KILLER' }),
+          actions,
+          { forcedVariant: 'KILLER' },
+        ),
+      );
+      // Only the mount effect runs; the forcedVariant-change effect is
+      // skipped on first render via the hasMountedRef guard.
+      expect(actions.newGame).not.toHaveBeenCalled();
+    });
+
+    it('ignores no-op forcedVariant changes (same variant, same string)', () => {
+      const actions = makeActions();
+      const state = makeState({ gameStatus: GAME_STATUS.PLAYING, sudokuType: 'KILLER' });
+      const { rerender } = renderHook(
+        ({ forcedVariant }: { forcedVariant: SudokuTypeId }) =>
+          useAutoStartIdle(state, actions, { forcedVariant }),
+        { initialProps: { forcedVariant: 'KILLER' satisfies SudokuTypeId } },
+      );
+      rerender({ forcedVariant: 'KILLER' });
+      expect(actions.newGame).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useAutoStartIdle.ts
+++ b/src/hooks/useAutoStartIdle.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { GAME_STATUS, DIFFICULTY_LEVELS, SUDOKU_TYPES } from '../utils/constants';
 import { recordGameStart } from '../utils/stats';
 import type { GameState, GameActions, DifficultyLevel, SudokuTypeId } from '../types/index';
@@ -65,4 +65,31 @@ export function useAutoStartIdle(
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount
+
+  // Variant-route-change effect (#223 bug 1). GameProvider stays
+  // mounted as the user navigates between /{lang}/{slug} routes, and
+  // the mount-only effect above doesn't re-fire — so the URL/<title>/
+  // landing copy update from VariantPage but the BOARD stays on the
+  // previous variant. SEO crawler sees mismatched URL+content; user
+  // sees Killer board on /thermo-sudoku page. We catch this by
+  // re-running the variant-mismatch branch whenever forcedVariant
+  // actually changes (post-mount).
+  //
+  // The hasMountedRef skips the first render so we don't double-fire
+  // with the mount effect above. We deliberately read state.sudokuType
+  // and state.difficulty from the closure but do NOT include them in
+  // the dep array — we only want to react to forcedVariant changes,
+  // not to every game-state churn.
+  const hasMountedRef = useRef(false);
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+    if (!forcedVariant) return;
+    if (state.sudokuType === forcedVariant) return;
+    actions.newGame(state.difficulty, forcedVariant);
+    recordGameStart(forcedVariant, state.difficulty);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [forcedVariant]);
 }

--- a/src/hooks/useLanguageSync.test.ts
+++ b/src/hooks/useLanguageSync.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLanguageSync } from './useLanguageSync';
+
+const changeLanguageMock = vi.fn();
+
+// Mutable mock so individual tests can rotate the "current" i18n
+// language between runs without re-importing.
+const i18nState = { language: 'en' };
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: {
+      get language() {
+        return i18nState.language;
+      },
+      changeLanguage: changeLanguageMock,
+    },
+  }),
+}));
+
+describe('useLanguageSync', () => {
+  beforeEach(() => {
+    changeLanguageMock.mockReset();
+    i18nState.language = 'en';
+    document.documentElement.lang = 'en';
+  });
+
+  afterEach(() => {
+    document.documentElement.lang = 'en';
+  });
+
+  it('changes i18n language when route lang differs', () => {
+    renderHook(() => useLanguageSync('ru'));
+    expect(changeLanguageMock).toHaveBeenCalledWith('ru');
+  });
+
+  it('does not change i18n language when route lang matches', () => {
+    i18nState.language = 'ru';
+    renderHook(() => useLanguageSync('ru'));
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+  });
+
+  // Regression #223 bug 2 — index.html ships <html lang="en"> hardcoded
+  // and the prerender pass snapshots whatever lang attribute is on the
+  // root element when the route renders. Without this side-effect, all
+  // 14 RU prerendered routes would ship lang="en", which is both an
+  // SEO and an a11y regression.
+  it('mirrors lang onto <html lang> for RU routes', () => {
+    renderHook(() => useLanguageSync('ru'));
+    expect(document.documentElement.lang).toBe('ru');
+  });
+
+  it('mirrors lang onto <html lang> for EN routes (idempotent set)', () => {
+    document.documentElement.lang = 'ru'; // simulate a stale value
+    renderHook(() => useLanguageSync('en'));
+    expect(document.documentElement.lang).toBe('en');
+  });
+
+  it('does NOT touch <html lang> for unsupported languages', () => {
+    document.documentElement.lang = 'en';
+    renderHook(() => useLanguageSync('zz'));
+    expect(document.documentElement.lang).toBe('en');
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useLanguageSync.ts
+++ b/src/hooks/useLanguageSync.ts
@@ -5,12 +5,21 @@ import { isSupportedLanguage } from '../utils/variantSlugs';
 /**
  * URL `:lang` is the source of truth for the active i18n language.
  * Whenever the route segment changes (browser nav, programmatic
- * navigate, deep-link), call i18next.changeLanguage to match. The
- * effect runs only when the lang string changes and gates on
- * isSupportedLanguage so an unrecognized URL segment can't poison the
- * i18n store — route guards already redirect those to a valid language
- * before this hook would see them, but we keep the guard as belt +
- * suspenders.
+ * navigate, deep-link), call i18next.changeLanguage to match AND
+ * mirror the language onto `<html lang>`. The effect runs only when
+ * the lang string changes and gates on isSupportedLanguage so an
+ * unrecognized URL segment can't poison the i18n store — route guards
+ * already redirect those to a valid language before this hook would
+ * see them, but we keep the guard as belt + suspenders.
+ *
+ * The `<html lang>` mirror exists for #223 bug 2: index.html ships
+ * `<html lang="en">` hardcoded, so without this side-effect every
+ * prerendered RU page (`/ru/*`, all 14 of them) would snapshot
+ * `lang="en"`. That's a real SEO + accessibility regression: Google
+ * de-ranks pages with mismatched lang, and screen readers use the
+ * wrong pronunciation rules for RU content. Setting it here means the
+ * Playwright prerender pass picks up the correct attribute when it
+ * snapshots the rendered DOM.
  */
 export function useLanguageSync(lang: string): void {
   const { i18n } = useTranslation();
@@ -20,5 +29,6 @@ export function useLanguageSync(lang: string): void {
     if (i18n.language !== lang) {
       i18n.changeLanguage(lang);
     }
+    document.documentElement.lang = lang;
   }, [lang, i18n]);
 }


### PR DESCRIPTION
## Summary
Closes #223. Two bugs from post-hoc /codex review of PR #108.

- **Variant→variant nav desync.** Client routing between `/en/killer-sudoku` and `/en/thermo-sudoku` updated `<title>`/`<h1>`/landing copy but the board stayed on the old variant — `GameProvider` was mounted, so `useAutoStartIdle`'s mount-only effect never re-fired. Added a post-mount `forcedVariant`-change effect (gated by a `hasMountedRef` so it doesn't double-fire with the existing mount logic).
- **`<html lang="en">` hardcoded for RU prerendered pages.** `index.html` shipped `lang="en"` and `useLanguageSync` only updated i18next, not the DOM attribute. Result: all 14 prerendered RU routes snapshot `lang="en"` — bad for SEO ranking and screen-reader pronunciation. Mirrored `lang` onto `document.documentElement.lang` inside the same effect; prerender's existing `networkidle` + meta + cell waits give it time to apply before capture.

## Test plan
- [x] `npx vitest run useAutoStartIdle.test useLanguageSync.test` — 17/17 pass.
- [x] Full unit suite, typecheck, lint all green locally.
- [ ] Manual: navigate `/en/killer-sudoku` → `/en/thermo-sudoku` in dev, confirm the board switches to Thermo (instead of staying Killer).
- [ ] Manual: prerender locally and `grep '<html lang="ru"' dist/ru/*/index.html` to confirm RU pages snapshot the correct attribute (was `en` before this PR).
- [ ] CI prerender + e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)