### PR TITLE
fix(pr-watcher): don't advance cursor on gh api failure (#225)

### DIFF
--- a/scripts/pr-watcher.sh
+++ b/scripts/pr-watcher.sh
@@ -76,57 +76,90 @@ poll_once() {
   echo "$ts" > "$LAST_POLL"
 
   # Open PRs authored by me. --json keeps the payload tiny.
+  # Bail on failure rather than masking with `|| echo '[]'` — silently
+  # treating a network/auth/rate-limit failure as "no PRs" hides the
+  # error and would let cursors advance under it (#225).
   local prs_json
-  prs_json=$(gh pr list --author @me --state open --json number,title,headRepositoryOwner,headRepository 2>/dev/null || echo '[]')
+  if ! prs_json=$(gh pr list --author @me --state open --json number,title,headRepositoryOwner,headRepository 2>/dev/null); then
+    echo "[pr-watcher] gh pr list failed; skipping this poll (cursors not advanced)" >&2
+    return 1
+  fi
 
-  echo "$prs_json" | jq -c '.[]' | while IFS= read -r pr; do
-    local pr_num pr_title cursor cursor_file
+  # Read PRs into an array. The previous code piped jq into a `while`
+  # loop, which runs in a subshell — `return` and shared state leak
+  # away from poll_once. The array form keeps the loop body in the
+  # function's own shell so per-PR failures can record an overall rc
+  # and cursor writes can be gated on success.
+  local -a prs=()
+  while IFS= read -r pr; do
+    [ -z "$pr" ] && continue
+    prs+=("$pr")
+  done < <(echo "$prs_json" | jq -c '.[]')
+
+  local rc=0
+  local pr pr_num pr_title cursor cursor_file comments reviews line author
+
+  for pr in "${prs[@]}"; do
     pr_num=$(echo "$pr" | jq -r .number)
     pr_title=$(echo "$pr" | jq -r .title)
     cursor_file="$CURSOR_DIR/pr-$pr_num.txt"
     cursor=$(cat "$cursor_file" 2>/dev/null || default_cursor)
 
     # 1. Issue comments (general PR discussion). `?since=` filters by
-    #    updated_at, which catches edits too. That's fine for our use
-    #    case — an edited review is still worth seeing.
-    #    --paginate follows Link headers across all pages so a long
-    #    outage that produces >100 events on resume can't silently drop
-    #    the tail (the cursor would otherwise advance to "now" past
-    #    events we never wrote).
-    gh api --paginate "repos/$REPO_NWO/issues/$pr_num/comments?since=$cursor&per_page=100" \
-      --jq '.[] | {pr: '"$pr_num"', kind: "comment", author: .user.login, url: .html_url, body: .body, ts: .updated_at}' 2>/dev/null \
-      | while IFS= read -r line; do
-          [ -z "$line" ] && continue
-          local author; author=$(echo "$line" | jq -r .author)
-          is_excluded "$author" && continue
-          # Trim body to 200 chars; flatten newlines so the JSONL stays
-          # one-line-per-event.
-          echo "$line" \
-            | jq -c --arg ts "$ts" --arg title "$pr_title" \
-                '{ts: $ts, pr: .pr, title: $title, kind: .kind, author: .author, url: .url, summary: (.body | gsub("\n"; " ") | .[0:200])}' \
-            >> "$INBOX_LOG"
-        done
+    #    updated_at, which catches edits too — an edited review is
+    #    still worth seeing. --paginate follows Link headers so a long
+    #    outage producing >100 events on resume can't silently drop
+    #    the tail (otherwise the cursor would advance past events we
+    #    never wrote). The output is captured into a variable so we
+    #    can detect a failed call and skip the cursor advance for this
+    #    PR — the original code piped directly to `while` which threw
+    #    the gh exit status away (#225). errexit is suppressed inside
+    #    poll_once because the watcher loop calls it as `poll_once || …`.
+    if ! comments=$(gh api --paginate "repos/$REPO_NWO/issues/$pr_num/comments?since=$cursor&per_page=100" \
+      --jq '.[] | {pr: '"$pr_num"', kind: "comment", author: .user.login, url: .html_url, body: .body, ts: .updated_at}' 2>/dev/null); then
+      echo "[pr-watcher] gh api failed (PR $pr_num issue comments); cursor not advanced" >&2
+      rc=1
+      continue
+    fi
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      author=$(echo "$line" | jq -r .author)
+      is_excluded "$author" && continue
+      # Trim body to 200 chars; flatten newlines so the JSONL stays
+      # one-line-per-event.
+      echo "$line" \
+        | jq -c --arg ts "$ts" --arg title "$pr_title" \
+            '{ts: $ts, pr: .pr, title: $title, kind: .kind, author: .author, url: .url, summary: (.body | gsub("\n"; " ") | .[0:200])}' \
+        >> "$INBOX_LOG"
+    done <<< "$comments"
 
     # 2. Formal PR reviews (the "Approve / Request changes / Comment"
     #    kind). The reviews endpoint doesn't support `?since=`, so we
-    #    filter client-side by `submitted_at`. --paginate ensures
-    #    long-tail correctness (same reasoning as comments above).
-    gh api --paginate "repos/$REPO_NWO/pulls/$pr_num/reviews?per_page=100" \
-      --jq '.[] | select(.submitted_at != null and .submitted_at > "'"$cursor"'") | {pr: '"$pr_num"', kind: "review", author: .user.login, url: .html_url, body: (.body // ""), ts: .submitted_at, state: .state}' 2>/dev/null \
-      | while IFS= read -r line; do
-          [ -z "$line" ] && continue
-          local author; author=$(echo "$line" | jq -r .author)
-          is_excluded "$author" && continue
-          echo "$line" \
-            | jq -c --arg ts "$ts" --arg title "$pr_title" \
-                '{ts: $ts, pr: .pr, title: $title, kind: (.kind + ":" + (.state // "")), author: .author, url: .url, summary: (.body | gsub("\n"; " ") | .[0:200])}' \
-            >> "$INBOX_LOG"
-        done
+    #    filter client-side by `submitted_at`. Same capture-and-bail
+    #    pattern as the comments call above.
+    if ! reviews=$(gh api --paginate "repos/$REPO_NWO/pulls/$pr_num/reviews?per_page=100" \
+      --jq '.[] | select(.submitted_at != null and .submitted_at > "'"$cursor"'") | {pr: '"$pr_num"', kind: "review", author: .user.login, url: .html_url, body: (.body // ""), ts: .submitted_at, state: .state}' 2>/dev/null); then
+      echo "[pr-watcher] gh api failed (PR $pr_num reviews); cursor not advanced" >&2
+      rc=1
+      continue
+    fi
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      author=$(echo "$line" | jq -r .author)
+      is_excluded "$author" && continue
+      echo "$line" \
+        | jq -c --arg ts "$ts" --arg title "$pr_title" \
+            '{ts: $ts, pr: .pr, title: $title, kind: (.kind + ":" + (.state // "")), author: .author, url: .url, summary: (.body | gsub("\n"; " ") | .[0:200])}' \
+        >> "$INBOX_LOG"
+    done <<< "$reviews"
 
-    # Update cursor unconditionally — failed pages would have errored
-    # out earlier under `set -e` before reaching here.
+    # Cursor advance only after BOTH gh api calls for this PR succeeded
+    # and we wrote any matching events. A future PR's failure won't
+    # roll this one back; we already wrote the events.
     echo "$ts" > "$cursor_file"
   done
+
+  return $rc
 }
 
 if [[ "${1:-}" == "--watch" ]]; then

--- a/scripts/pr-watcher.sh
+++ b/scripts/pr-watcher.sh
@@ -137,6 +137,13 @@ poll_once() {
     #    kind). The reviews endpoint doesn't support `?since=`, so we
     #    filter client-side by `submitted_at`. Same capture-and-bail
     #    pattern as the comments call above.
+    #
+    # NOTE: at-least-once delivery is intentional. If this call fails
+    # AFTER the comments call already wrote events to INBOX_LOG, the
+    # cursor stays frozen — the next poll re-fetches the same comments
+    # and writes them again. We accept the duplicate over the
+    # alternative (advancing cursor and silently losing the missing
+    # reviews). Downstream consumers MUST tolerate duplicates.
     if ! reviews=$(gh api --paginate "repos/$REPO_NWO/pulls/$pr_num/reviews?per_page=100" \
       --jq '.[] | select(.submitted_at != null and .submitted_at > "'"$cursor"'") | {pr: '"$pr_num"', kind: "review", author: .user.login, url: .html_url, body: (.body // ""), ts: .submitted_at, state: .state}' 2>/dev/null); then
       echo "[pr-watcher] gh api failed (PR $pr_num reviews); cursor not advanced" >&2

--- a/scripts/pr-watcher.test.sh
+++ b/scripts/pr-watcher.test.sh
@@ -89,13 +89,13 @@ fails=0
   if assert "[ -f '$cursor_file' ]" "cursor file should exist after happy poll"; then
     cursor_value=$(cat "$cursor_file")
     if assert "[[ '$cursor_value' =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]" "cursor should be ISO timestamp, got '$cursor_value'"; then
-      ((passes++))
+      passes=$((passes + 1))
       echo "PASS: happy path advances cursor"
     else
-      ((fails++))
+      fails=$((fails + 1))
     fi
   else
-    ((fails++))
+    fails=$((fails + 1))
   fi
   rm -rf "$sandbox"
 }
@@ -109,10 +109,10 @@ fails=0
   run_poll "$sandbox" >/dev/null 2>&1 || true  # poll_once returns 1 — that's the point
   cursor_file="$sandbox/inbox/cursors/pr-99.txt"
   if assert "[ ! -f '$cursor_file' ]" "cursor file must NOT exist after gh failure"; then
-    ((passes++))
+    passes=$((passes + 1))
     echo "PASS: gh api comments failure does not create cursor"
   else
-    ((fails++))
+    fails=$((fails + 1))
   fi
   rm -rf "$sandbox"
 }
@@ -129,10 +129,10 @@ fails=0
   run_poll "$sandbox" >/dev/null 2>&1 || true
   cursor_value=$(cat "$cursor_file")
   if assert "[ '$cursor_value' = '2020-01-01T00:00:00Z' ]" "cursor must remain frozen on gh reviews failure (got '$cursor_value')"; then
-    ((passes++))
+    passes=$((passes + 1))
     echo "PASS: gh api reviews failure does not advance cursor"
   else
-    ((fails++))
+    fails=$((fails + 1))
   fi
   rm -rf "$sandbox"
 }

--- a/scripts/pr-watcher.test.sh
+++ b/scripts/pr-watcher.test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# pr-watcher.test.sh — regression test for #225 (silent cursor advance
+# on gh api failure). Runs poll_once with a mocked `gh` shim and
+# asserts cursor-advance semantics.
+#
+# Usage: ./scripts/pr-watcher.test.sh
+# Exit 0 = all assertions passed; nonzero = a failure (printed to stderr).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_WATCHER="$SCRIPT_DIR/pr-watcher.sh"
+
+# Each test gets a fresh inbox + a fresh fake-gh on PATH.
+make_sandbox() {
+  local sandbox; sandbox=$(mktemp -d -t pr-watcher-test.XXXX)
+  mkdir -p "$sandbox/inbox/cursors" "$sandbox/bin"
+  echo "$sandbox"
+}
+
+# Build a fake gh that replays canned responses for the URLs/args we
+# care about. $1 is the sandbox dir; the canonical fixture set is
+# defined inline.
+write_fake_gh() {
+  local sandbox="$1"
+  local mode="$2"  # "ok" | "fail-pulls" | "fail-comments"
+
+  cat > "$sandbox/bin/gh" <<GHFAKE
+#!/usr/bin/env bash
+set -euo pipefail
+ARGS="\$*"
+case "\$ARGS" in
+  *"repo view"*"nameWithOwner"*)
+    echo "LeoMo42/sudoku-cc"
+    exit 0
+    ;;
+  *"pr list"*)
+    echo '[{"number": 99, "title": "test pr", "headRepositoryOwner": {"login": "LeoMo42"}, "headRepository": {"name": "sudoku-cc"}}]'
+    exit 0
+    ;;
+  *"issues/99/comments"*)
+    if [ "$mode" = "fail-comments" ]; then
+      echo "fake gh: simulated comments failure" >&2
+      exit 1
+    fi
+    # Empty events list — we're testing cursor semantics, not body parsing.
+    exit 0
+    ;;
+  *"pulls/99/reviews"*)
+    if [ "$mode" = "fail-pulls" ]; then
+      echo "fake gh: simulated reviews failure" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+esac
+echo "fake gh: unhandled call: \$ARGS" >&2
+exit 2
+GHFAKE
+  chmod +x "$sandbox/bin/gh"
+}
+
+run_poll() {
+  local sandbox="$1"
+  PATH="$sandbox/bin:$PATH" \
+  PR_WATCHER_INBOX="$sandbox/inbox" \
+    bash "$PR_WATCHER"
+}
+
+assert() {
+  local cond="$1" msg="$2"
+  if ! eval "$cond"; then
+    echo "FAIL: $msg" >&2
+    echo "  cond: $cond" >&2
+    return 1
+  fi
+}
+
+passes=0
+fails=0
+
+# Test 1: happy path — cursor file is created and contains a timestamp.
+{
+  sandbox=$(make_sandbox)
+  write_fake_gh "$sandbox" "ok"
+  run_poll "$sandbox" >/dev/null
+  cursor_file="$sandbox/inbox/cursors/pr-99.txt"
+  if assert "[ -f '$cursor_file' ]" "cursor file should exist after happy poll"; then
+    cursor_value=$(cat "$cursor_file")
+    if assert "[[ '$cursor_value' =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]" "cursor should be ISO timestamp, got '$cursor_value'"; then
+      ((passes++))
+      echo "PASS: happy path advances cursor"
+    else
+      ((fails++))
+    fi
+  else
+    ((fails++))
+  fi
+  rm -rf "$sandbox"
+}
+
+# Test 2: gh api fails on the comments call — cursor must NOT exist
+# (regression for #225). Pre-existing cursor would also stay frozen,
+# which we cover in test 3.
+{
+  sandbox=$(make_sandbox)
+  write_fake_gh "$sandbox" "fail-comments"
+  run_poll "$sandbox" >/dev/null 2>&1 || true  # poll_once returns 1 — that's the point
+  cursor_file="$sandbox/inbox/cursors/pr-99.txt"
+  if assert "[ ! -f '$cursor_file' ]" "cursor file must NOT exist after gh failure"; then
+    ((passes++))
+    echo "PASS: gh api comments failure does not create cursor"
+  else
+    ((fails++))
+  fi
+  rm -rf "$sandbox"
+}
+
+# Test 3: pre-existing cursor + gh failure — cursor stays frozen at
+# its old value (this is the data-loss path: previously the code
+# advanced cursor to "now", permanently skipping events between the
+# old cursor and now).
+{
+  sandbox=$(make_sandbox)
+  write_fake_gh "$sandbox" "fail-pulls"
+  cursor_file="$sandbox/inbox/cursors/pr-99.txt"
+  echo "2020-01-01T00:00:00Z" > "$cursor_file"
+  run_poll "$sandbox" >/dev/null 2>&1 || true
+  cursor_value=$(cat "$cursor_file")
+  if assert "[ '$cursor_value' = '2020-01-01T00:00:00Z' ]" "cursor must remain frozen on gh reviews failure (got '$cursor_value')"; then
+    ((passes++))
+    echo "PASS: gh api reviews failure does not advance cursor"
+  else
+    ((fails++))
+  fi
+  rm -rf "$sandbox"
+}
+
+echo ""
+echo "Passes: $passes  Fails: $fails"
+[ "$fails" -eq 0 ]


### PR DESCRIPTION
## Summary
Closes #225. `pr-watcher.sh poll_once` was called as `poll_once || ...` from the watcher loop, which suppresses errexit inside the function. A failed `gh api` then ran past the unconditional cursor write, silently advancing past events we never logged. Result: any transient gh failure permanently skipped events between the old cursor and "now" — the exact failure mode the cursor design was meant to prevent.

Restructure:
- Capture each `gh` call into a variable and bail (continue / return 1) on non-zero exit instead of piping into `while read`. The pipe form ran the loop body in a subshell and threw the gh exit code away.
- Read the PR list into an array so `continue`/`return` semantics work in the function's own shell.
- Advance per-PR cursors only after BOTH `gh api` calls for that PR succeed.
- Return non-zero from `poll_once` if any per-PR poll failed (so the watcher's existing "will retry" log fires).

Also bail on `gh pr list` failure — the previous `|| echo '[]'` fallback silently treated it as "no PRs", masking the same class of error.

## Test plan
- [x] `scripts/pr-watcher.test.sh` — three regression cases against a fake `gh` shim. Cases 2 + 3 would have failed against the previous code.
- [x] Manually checked: happy-path watcher run logs new comments without changing observed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)