### PR TITLE
chore(ci): add least-privilege permissions block to ci.yml (#228)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [dev, main]
 
+# Least-privilege token (#228). CI only checks out the repo and runs
+# build/lint/test/e2e — none of which need to write to GitHub. The
+# default GITHUB_TOKEN scope depends on the repo setting, which can
+# silently widen if anyone flips the org/repo default to write. Pin
+# this workflow to read-only so the blast radius can't grow under us.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
Closes #228. `ci.yml` runs on `pull_request` (so it executes PR-author-supplied tooling via npm) without an explicit `permissions:` block. That meant GITHUB_TOKEN scope was inherited from whatever the repo/org default happens to be — fine today, silently widens if the default ever flips. Pinned the workflow to `contents: read`, which is sufficient for checkout + npm + lint/typecheck/test/build. The other three workflows (deploy, claude-pr-review, codex-pr-review) already have their own scoped permissions blocks; this was the last one exposed.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean.
- [ ] CI run on this PR completes (verifies the workflow still has all the access it needs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)