### PR TITLE
fix(prerender): close preview server when chromium.launch fails (#227)

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -69,6 +69,28 @@ function hreflangAlternates(slug) {
   return LANGS.map((lang) => ({ lang, href: canonicalUrl(lang, slug) }));
 }
 
+/**
+ * Tear down the prerender preview server + Playwright browser. Exported
+ * (and split out) so the cleanup contract is unit-testable: the
+ * regression we're guarding against (#227) is "browser undefined ⇒
+ * server still closes," which is hard to exercise without mocking vite
+ * AND playwright in concert. With a helper, the test calls it directly.
+ *
+ * - `Promise.allSettled` so if one close rejects, the other still runs.
+ *   Sequential `await` would leak the preview server when
+ *   browser.close() throws first. CI shrugs (process exits), local
+ *   re-runs care (port 4173 stays bound).
+ * - `browser` may be undefined when chromium.launch() threw — skip the
+ *   close call but still tear the server down. That's exactly the
+ *   #227 leak path.
+ */
+export async function closeAll(browser, server) {
+  return Promise.allSettled([
+    browser ? browser.close() : Promise.resolve(),
+    new Promise((res) => server.httpServer.close(res)),
+  ]);
+}
+
 async function prerender() {
   // Vite preview reads `base` from vite.config.ts unless overridden.
   // We pass it explicitly so the script works regardless of how the
@@ -85,11 +107,21 @@ async function prerender() {
   const baseUrl = `${origin}${BASE.replace(/\/$/, '')}`;
   console.log(`[prerender] preview server at ${baseUrl}`);
 
-  const browser = await chromium.launch();
   const errors = [];
   const written = [];
+  // `browser` lives outside the try so the finally can close it
+  // regardless of where launch failed. The previous shape declared it
+  // INSIDE the try with `const browser = await chromium.launch();`,
+  // which meant a failed launch (chromium not installed, missing
+  // system deps, sandbox-disabled env) jumped straight out of
+  // prerender() with the preview server still bound to port 4173 —
+  // local re-runs then hit `Error: listen EADDRINUSE :::4173` until
+  // the kernel reclaimed the socket (#227).
+  let browser;
 
   try {
+    browser = await chromium.launch();
+
     for (const route of ROUTES) {
       const url = `${baseUrl}${route}`;
       const ctx = await browser.newContext();
@@ -130,13 +162,7 @@ async function prerender() {
       await ctx.close();
     }
   } finally {
-    // Promise.allSettled so if either close throws, the other still runs.
-    // Sequential `await` would leak the preview server if browser.close()
-    // failed first. CI shrugs (process exits anyway), local re-runs care.
-    await Promise.allSettled([
-      browser.close(),
-      new Promise((res) => server.httpServer.close(res)),
-    ]);
+    await closeAll(browser, server);
   }
 
   if (errors.length) {

--- a/scripts/prerender.test.ts
+++ b/scripts/prerender.test.ts
@@ -1,0 +1,53 @@
+// Regression #227 — closeAll must tear down the preview server even
+// when the Playwright browser handle is undefined (chromium.launch
+// threw before assignment). The previous shape declared `const browser
+// = await chromium.launch()` outside any try, so a failed launch left
+// the preview server bound to port 4173 and made local re-runs hit
+// `Error: listen EADDRINUSE :::4173` until the kernel reclaimed the
+// socket.
+import { describe, it, expect, vi } from 'vitest';
+// @ts-expect-error — .mjs ESM script, no types file
+import { closeAll } from './prerender.mjs';
+
+interface FakeServer {
+  httpServer: { close: (cb: () => void) => void };
+}
+
+function makeFakeServer(): FakeServer & { closeMock: ReturnType<typeof vi.fn> } {
+  const closeMock = vi.fn((cb: () => void) => cb());
+  return {
+    httpServer: { close: closeMock },
+    closeMock,
+  } as FakeServer & { closeMock: ReturnType<typeof vi.fn> };
+}
+
+describe('closeAll', () => {
+  it('closes the server even when browser is undefined', async () => {
+    const server = makeFakeServer();
+    const results = await closeAll(undefined, server);
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(server.closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes both browser and server on the happy path', async () => {
+    const browserClose = vi.fn().mockResolvedValue(undefined);
+    const browser = { close: browserClose };
+    const server = makeFakeServer();
+    await closeAll(browser, server);
+    expect(browserClose).toHaveBeenCalledTimes(1);
+    expect(server.closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still closes the server when browser.close() rejects', async () => {
+    const browser = {
+      close: vi.fn().mockRejectedValue(new Error('browser teardown failed')),
+    };
+    const server = makeFakeServer();
+    const results = await closeAll(browser, server);
+    // Promise.allSettled means we get one rejection (browser) and one
+    // fulfilment (server) — never short-circuit on the first failure.
+    expect(results[0]?.status).toBe('rejected');
+    expect(results[1]?.status).toBe('fulfilled');
+    expect(server.closeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'scripts/**/*.test.{ts,tsx}'],
     exclude: ['node_modules/**', 'src/**/*.stories.tsx'],
     pool: 'forks',
     teardownTimeout: 3000,


### PR DESCRIPTION
## Summary
Closes #227. `prerender.mjs` started the Vite preview server before launching Playwright, then declared `const browser = await chromium.launch()` outside any try/finally. A failed launch (no chromium install, missing system deps, sandbox-disabled env) left the server still bound to port 4173, so local re-runs hit `Error: listen EADDRINUSE :::4173` until the kernel reclaimed the socket.

- Moved `let browser` declaration above the try, assignment inside, and gated the close call on `browser ?` so the finally still closes the server even when launch never returned a handle.
- Extracted cleanup into `closeAll(browser, server)` so the regression case is unit-testable without mocking vite + playwright together.
- Three tests pin: undefined browser → server still closes (the #227 leak), happy path closes both, browser-close rejection still lets server close (Promise.allSettled).

## Test plan
- [x] `npx vitest run scripts/prerender.test.ts` — 3/3 pass.
- [x] Typecheck + lint clean.
- [ ] Manual repro: in a worktree without playwright chromium installed, run `npm run prerender` and confirm port 4173 is freed (`lsof -i :4173` returns nothing) after the script exits.
- [ ] CI deploy.yml workflow still runs end-to-end (validates the happy path is unbroken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)