### PR TITLE
fix(routing): align language storage key + preserve query on root redirect (#226)

### DIFF
--- a/src/components/Routes/RootRedirect.test.tsx
+++ b/src/components/Routes/RootRedirect.test.tsx
@@ -1,0 +1,66 @@
+// Regression #226 bug 2 — RootRedirect dropped query params on the
+// way to /{lang}, breaking deep-links like
+// `?type=KILLER&difficulty=EXPERT` that useAutoStartIdle reads to
+// auto-start a specific puzzle.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { RootRedirect } from './RootRedirect';
+
+// Probe component that surfaces the URL the redirect landed on so the
+// assertion can inspect both pathname and search.
+function LocationProbe() {
+  const loc = useLocation();
+  return (
+    <div data-testid="probe">
+      {loc.pathname}|{loc.search}
+    </div>
+  );
+}
+
+function renderAt(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/" element={<RootRedirect />} />
+        <Route path="/:lang" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RootRedirect', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Pin navigator to a value that doesn't accidentally match a
+    // supported language so the test outcomes are deterministic.
+    Object.defineProperty(window, 'navigator', {
+      value: { language: 'en-US' },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('redirects to the preferred language root when there is no query', () => {
+    localStorage.setItem('language', 'ru');
+    const { getByTestId } = renderAt('/');
+    expect(getByTestId('probe').textContent).toBe('/ru|');
+  });
+
+  it('preserves location.search through the redirect', () => {
+    localStorage.setItem('language', 'en');
+    const { getByTestId } = renderAt('/?type=KILLER&difficulty=EXPERT');
+    expect(getByTestId('probe').textContent).toBe(
+      '/en|?type=KILLER&difficulty=EXPERT',
+    );
+  });
+
+  it('preserves a single-key search string too', () => {
+    localStorage.setItem('language', 'ru');
+    const { getByTestId } = renderAt('/?seed=12345');
+    expect(getByTestId('probe').textContent).toBe('/ru|?seed=12345');
+  });
+});

--- a/src/components/Routes/RootRedirect.tsx
+++ b/src/components/Routes/RootRedirect.tsx
@@ -1,12 +1,20 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { detectPreferredLanguage } from '../../utils/variantSlugs';
 
 /**
  * Bare `/` lands here. Picks the user's preferred language (localStorage
  * > navigator.language > 'en') and redirects to `/{lang}`. `replace` so
  * the empty-path entry doesn't pollute browser history.
+ *
+ * Preserves `location.search` so query-param deep-links survive the
+ * redirect (#226 bug 2). useAutoStartIdle reads `?type=` and
+ * `?difficulty=` to auto-start a specific puzzle; before this fix,
+ * `https://leomo42.github.io/sudoku-cc/?type=KILLER&difficulty=EXPERT`
+ * landed on default Classic Medium because the search string was
+ * dropped at this hop.
  */
 export function RootRedirect() {
   const lang = detectPreferredLanguage();
-  return <Navigate to={`/${lang}`} replace />;
+  const { search } = useLocation();
+  return <Navigate to={{ pathname: `/${lang}`, search }} replace />;
 }

--- a/src/utils/variantSlugs.test.ts
+++ b/src/utils/variantSlugs.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   VARIANT_SLUGS,
   variantFromSlug,
   slugFromVariant,
   isSupportedLanguage,
   SUPPORTED_LANGUAGES,
+  detectPreferredLanguage,
 } from './variantSlugs';
 import { SUDOKU_TYPES } from './constants';
 import type { SudokuTypeId } from '../types/index';
@@ -56,6 +57,57 @@ describe('isSupportedLanguage', () => {
     expect(isSupportedLanguage('en-US')).toBe(false);
     expect(isSupportedLanguage('')).toBe(false);
     expect(isSupportedLanguage(undefined)).toBe(false);
+  });
+});
+
+// Regression #226 bug 1 — detectPreferredLanguage was reading
+// `i18nextLng` (the i18next library default), but src/i18n/config.js
+// writes the user's saved preference to `language`. The two never
+// agreed, so RU users on EN-default browsers landed on /en every
+// visit. This test pins the storage key to the one i18n actually
+// writes.
+describe('detectPreferredLanguage', () => {
+  const origNavigator = window.navigator;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'navigator', {
+      value: origNavigator,
+      configurable: true,
+    });
+  });
+
+  function setNavigatorLanguage(lang: string) {
+    Object.defineProperty(window, 'navigator', {
+      value: { language: lang },
+      configurable: true,
+    });
+  }
+
+  it('reads localStorage["language"] (NOT "i18nextLng")', () => {
+    localStorage.setItem('language', 'ru');
+    localStorage.setItem('i18nextLng', 'en'); // stale value from a prior reader
+    setNavigatorLanguage('en-US');
+    expect(detectPreferredLanguage()).toBe('ru');
+  });
+
+  it('falls back to navigator.language when localStorage["language"] is unset', () => {
+    setNavigatorLanguage('ru-RU');
+    expect(detectPreferredLanguage()).toBe('ru');
+  });
+
+  it('returns "en" when neither storage nor navigator yields a supported language', () => {
+    setNavigatorLanguage('de-DE');
+    expect(detectPreferredLanguage()).toBe('en');
+  });
+
+  it('rejects unsupported localStorage values and falls through to navigator', () => {
+    localStorage.setItem('language', 'zz');
+    setNavigatorLanguage('ru-RU');
+    expect(detectPreferredLanguage()).toBe('ru');
   });
 });
 

--- a/src/utils/variantSlugs.ts
+++ b/src/utils/variantSlugs.ts
@@ -56,10 +56,18 @@ export function isSupportedLanguage(lang: string | undefined): lang is Supported
 /**
  * Resolve the user's preferred language: localStorage > browser hint > 'en'.
  * Used by the root `/` redirect to pick which `/{lang}` to go to.
+ *
+ * The localStorage key MUST match what i18n/config.js actually writes
+ * (`localStorage.setItem('language', lng)` in the languageChanged
+ * listener). The previous code read `'i18nextLng'` — i18next's library
+ * default — but the app never writes there, so the user's saved
+ * preference was always missed and the redirect fell through to
+ * navigator.language. RU users on non-RU browsers landed on EN every
+ * visit. (#226 bug 1).
  */
 export function detectPreferredLanguage(): SupportedLanguage {
   if (typeof window === 'undefined') return 'en';
-  const stored = window.localStorage?.getItem('i18nextLng');
+  const stored = window.localStorage?.getItem('language');
   if (isSupportedLanguage(stored ?? undefined)) return stored as SupportedLanguage;
   const navLang = navigator.language?.slice(0, 2);
   if (isSupportedLanguage(navLang)) return navLang;


### PR DESCRIPTION
## Summary
Closes #226. Two routing bugs from the post-hoc /codex review of PR #108.

- **i18n storage-key mismatch.** `detectPreferredLanguage` read `localStorage["i18nextLng"]` (i18next's library default), but `src/i18n/config.js` writes the saved preference to `localStorage["language"]`. The two never agreed — a RU user's saved preference was silently missed by the `/` redirect and unsupported-language redirects fell through to `navigator.language`. Pinned the read to `"language"`. No migration needed: the prior code only ever wrote to `"language"`, so no `"i18nextLng"` values ever existed.
- **RootRedirect dropped query params.** `<Navigate to={\`/\${lang}\`} replace />` discarded `location.search`. Deep-links like `?type=KILLER&difficulty=EXPERT` (which `useAutoStartIdle` reads to auto-start a specific puzzle) landed on default Classic Medium. Switched to a `{ pathname, search }` target so the search survives.

## Test plan
- [x] `npx vitest run` — full suite green; 7 new tests across the two files (4 `detectPreferredLanguage`, 3 `RootRedirect`).
- [x] Typecheck + lint clean.
- [ ] Manual: set language to RU in the EN/RU switcher, restart, hit `/`, confirm landing on `/ru` (was `/en` because of the key mismatch).
- [ ] Manual: visit `/?type=KILLER&difficulty=EXPERT` and confirm the app auto-starts a Killer Expert puzzle (was Classic Medium because the search was dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)