### PR TITLE
fix(bestTime): key by variant+difficulty, migrate v1 entries (#222)

### DIFF
--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -153,7 +153,7 @@ export function GameContainer({ forcedVariant, headingTitle, landingContent }: G
     if (state.gameStatus === GAME_STATUS.COMPLETED && prevStatus !== GAME_STATUS.COMPLETED) {
       // Use the ref instead of state.elapsedTime so this effect doesn't
       // depend on the timer tick (see #143).
-      isNewBestTimeRef.current = updateBestTime(state.difficulty, elapsedTimeRef.current);
+      isNewBestTimeRef.current = updateBestTime(state.sudokuType, state.difficulty, elapsedTimeRef.current);
       recordGameComplete(state.sudokuType, state.difficulty, elapsedTimeRef.current, state.mistakeCount);
       playVictorySound();
       vibrateComplete();

--- a/src/utils/bestTime.test.ts
+++ b/src/utils/bestTime.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getBestTime, updateBestTime } from './bestTime';
 
+const STORAGE_KEY = 'sudoku-best-times';
+
 describe('bestTime', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -11,51 +13,125 @@ describe('bestTime', () => {
   });
 
   it('returns null when no best time stored', () => {
-    expect(getBestTime('EASY')).toBeNull();
+    expect(getBestTime('CLASSIC', 'EASY')).toBeNull();
   });
 
   it('updateBestTime saves first completion and returns true', () => {
-    expect(updateBestTime('EASY', 120)).toBe(true);
-    expect(getBestTime('EASY')).toBe(120);
+    expect(updateBestTime('CLASSIC', 'EASY', 120)).toBe(true);
+    expect(getBestTime('CLASSIC', 'EASY')).toBe(120);
   });
 
   it('updateBestTime returns true and updates when new time is faster', () => {
-    updateBestTime('MEDIUM', 200);
-    expect(updateBestTime('MEDIUM', 150)).toBe(true);
-    expect(getBestTime('MEDIUM')).toBe(150);
+    updateBestTime('CLASSIC', 'MEDIUM', 200);
+    expect(updateBestTime('CLASSIC', 'MEDIUM', 150)).toBe(true);
+    expect(getBestTime('CLASSIC', 'MEDIUM')).toBe(150);
   });
 
   it('updateBestTime returns false and keeps old time when new time is slower', () => {
-    updateBestTime('HARD', 100);
-    expect(updateBestTime('HARD', 200)).toBe(false);
-    expect(getBestTime('HARD')).toBe(100);
+    updateBestTime('CLASSIC', 'HARD', 100);
+    expect(updateBestTime('CLASSIC', 'HARD', 200)).toBe(false);
+    expect(getBestTime('CLASSIC', 'HARD')).toBe(100);
   });
 
   it('updateBestTime returns false when new time equals the best', () => {
-    updateBestTime('EXPERT', 300);
-    expect(updateBestTime('EXPERT', 300)).toBe(false);
+    updateBestTime('CLASSIC', 'EXPERT', 300);
+    expect(updateBestTime('CLASSIC', 'EXPERT', 300)).toBe(false);
   });
 
   it('stores times independently per difficulty', () => {
-    updateBestTime('EASY', 90);
-    updateBestTime('HARD', 400);
-    expect(getBestTime('EASY')).toBe(90);
-    expect(getBestTime('MEDIUM')).toBeNull();
-    expect(getBestTime('HARD')).toBe(400);
+    updateBestTime('CLASSIC', 'EASY', 90);
+    updateBestTime('CLASSIC', 'HARD', 400);
+    expect(getBestTime('CLASSIC', 'EASY')).toBe(90);
+    expect(getBestTime('CLASSIC', 'MEDIUM')).toBeNull();
+    expect(getBestTime('CLASSIC', 'HARD')).toBe(400);
+  });
+
+  // Regression #222 — same difficulty across variants used to share
+  // a single key, so a fast Classic Easy hid (and was hidden by) a
+  // slower Killer Easy. The v2 schema separates them.
+  it('stores times independently per variant for the same difficulty', () => {
+    updateBestTime('CLASSIC', 'EASY', 120);
+    updateBestTime('KILLER', 'EASY', 285);
+    expect(getBestTime('CLASSIC', 'EASY')).toBe(120);
+    expect(getBestTime('KILLER', 'EASY')).toBe(285);
+  });
+
+  it('updating one variant does not affect another at the same difficulty', () => {
+    updateBestTime('CLASSIC', 'EASY', 120);
+    updateBestTime('KILLER', 'EASY', 285);
+    // Faster Classic Easy should not move Killer Easy.
+    expect(updateBestTime('CLASSIC', 'EASY', 90)).toBe(true);
+    expect(getBestTime('CLASSIC', 'EASY')).toBe(90);
+    expect(getBestTime('KILLER', 'EASY')).toBe(285);
+    // Slower Killer attempt should not displace its existing best.
+    expect(updateBestTime('KILLER', 'EASY', 400)).toBe(false);
+    expect(getBestTime('KILLER', 'EASY')).toBe(285);
   });
 
   it('getBestTime returns null when localStorage.getItem throws', () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new DOMException('blocked');
     });
-    expect(getBestTime('EASY')).toBeNull();
+    expect(getBestTime('CLASSIC', 'EASY')).toBeNull();
   });
 
   it('updateBestTime returns false and does not throw when setItem throws', () => {
     vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new DOMException('quota exceeded');
     });
-    expect(() => updateBestTime('EASY', 100)).not.toThrow();
-    expect(updateBestTime('EASY', 100)).toBe(false);
+    expect(() => updateBestTime('CLASSIC', 'EASY', 100)).not.toThrow();
+    expect(updateBestTime('CLASSIC', 'EASY', 100)).toBe(false);
+  });
+
+  describe('v1 → v2 migration', () => {
+    it('migrates a v1 store as if every entry were CLASSIC', () => {
+      // v1 shape: unversioned, keyed by difficulty alone.
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ EASY: 120, MEDIUM: 285, HARD: 410, EXPERT: 600 }),
+      );
+      expect(getBestTime('CLASSIC', 'EASY')).toBe(120);
+      expect(getBestTime('CLASSIC', 'EXPERT')).toBe(600);
+      // Other variants must NOT inherit the migrated values — that's
+      // the conflation bug we're closing.
+      expect(getBestTime('KILLER', 'EASY')).toBeNull();
+      expect(getBestTime('THERMO', 'MEDIUM')).toBeNull();
+    });
+
+    it('persists the migrated store back to localStorage on the first read', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ EASY: 120 }));
+      getBestTime('CLASSIC', 'EASY'); // triggers migration
+      const raw = localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw!) as { version: number; times: Record<string, number> };
+      expect(parsed.version).toBe(2);
+      expect(parsed.times['CLASSIC-EASY']).toBe(120);
+      expect(parsed.times['EASY']).toBeUndefined();
+    });
+
+    it('drops non-numeric entries during migration', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ EASY: 120, MEDIUM: 'oops', HARD: null }),
+      );
+      expect(getBestTime('CLASSIC', 'EASY')).toBe(120);
+      expect(getBestTime('CLASSIC', 'MEDIUM')).toBeNull();
+      expect(getBestTime('CLASSIC', 'HARD')).toBeNull();
+    });
+
+    it('drops a future-version store rather than guessing its shape', () => {
+      // A future writer has shipped v3 — until we ship code that
+      // understands it, treat it as empty rather than corrupting it.
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ version: 99, times: { 'CLASSIC-EASY': 120 } }),
+      );
+      expect(getBestTime('CLASSIC', 'EASY')).toBeNull();
+    });
+
+    it('handles malformed JSON without throwing', () => {
+      localStorage.setItem(STORAGE_KEY, '{not valid json');
+      expect(getBestTime('CLASSIC', 'EASY')).toBeNull();
+    });
   });
 });

--- a/src/utils/bestTime.ts
+++ b/src/utils/bestTime.ts
@@ -1,39 +1,120 @@
-import type { DifficultyLevel } from '../types/index';
+import type { DifficultyLevel, SudokuTypeId } from '../types/index';
 
 const BEST_TIMES_KEY = 'sudoku-best-times';
+const BEST_TIMES_VERSION = 2;
 
-type BestTimes = Partial<Record<DifficultyLevel, number>>;
+// v2 schema: best times are keyed by `${type}-${difficulty}` so a fast
+// Classic Easy doesn't overwrite (or hide) the legitimately-slower
+// Killer Easy. v1 was keyed by difficulty alone, conflating every
+// variant — see #222 for the user-visible bug. We migrate v1 entries
+// into v2 by assuming they were all CLASSIC, which is the only safe
+// guess (Classic is the default variant and was the only one most
+// users completed before variant gameplay shipped).
+type StoreV2 = {
+  version: 2;
+  times: Record<string, number>;
+};
 
-function loadBestTimes(): BestTimes {
+function statsKey(type: SudokuTypeId, difficulty: DifficultyLevel): string {
+  return `${type}-${difficulty}`;
+}
+
+function emptyStore(): StoreV2 {
+  return { version: BEST_TIMES_VERSION, times: {} };
+}
+
+// v1 was the unversioned shape `{ EASY: 142, MEDIUM: 285, ... }` — no
+// `version` field, all top-level keys are DifficultyLevel names. We
+// detect it by absence of `version` and convert each entry to a
+// CLASSIC-prefixed key. The original key set was only the four
+// DifficultyLevel values, so the new map has at most 4 entries.
+function migrateFromV1(raw: Record<string, unknown>): StoreV2 {
+  const times: Record<string, number> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v === 'number' && Number.isFinite(v)) {
+      times[`CLASSIC-${k}`] = v;
+    }
+  }
+  return { version: BEST_TIMES_VERSION, times };
+}
+
+function loadStore(): StoreV2 {
   try {
     const raw = localStorage.getItem(BEST_TIMES_KEY);
-    if (!raw) return {};
+    if (!raw) return emptyStore();
     const parsed = JSON.parse(raw) as unknown;
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
-    return parsed as BestTimes;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return emptyStore();
+    }
+    const obj = parsed as Record<string, unknown>;
+
+    // v1 → v2 migration. v1 had no `version` field; all values were
+    // numbers keyed by DifficultyLevel (EASY/MEDIUM/HARD/EXPERT).
+    if (!('version' in obj)) {
+      const migrated = migrateFromV1(obj);
+      saveStore(migrated);
+      return migrated;
+    }
+
+    if (obj.version !== BEST_TIMES_VERSION) return emptyStore();
+
+    const rawTimes = obj.times;
+    if (typeof rawTimes !== 'object' || rawTimes === null || Array.isArray(rawTimes)) {
+      return emptyStore();
+    }
+    // Drop any non-numeric entries defensively (in case a future writer
+    // ships malformed data).
+    const times: Record<string, number> = {};
+    for (const [k, v] of Object.entries(rawTimes)) {
+      if (typeof v === 'number' && Number.isFinite(v)) times[k] = v;
+    }
+    return { version: BEST_TIMES_VERSION, times };
   } catch {
-    return {};
+    return emptyStore();
   }
 }
 
-/** Returns the current best completion time (seconds) for a difficulty, or null if none. */
-export function getBestTime(difficulty: DifficultyLevel): number | null {
-  const times = loadBestTimes();
-  const t = times[difficulty];
+function saveStore(store: StoreV2): void {
+  try {
+    localStorage.setItem(BEST_TIMES_KEY, JSON.stringify(store));
+  } catch {
+    // localStorage unavailable (e.g. private browsing quota exceeded)
+  }
+}
+
+/**
+ * Returns the current best completion time (seconds) for a
+ * variant+difficulty pair, or null if none.
+ */
+export function getBestTime(
+  type: SudokuTypeId,
+  difficulty: DifficultyLevel,
+): number | null {
+  const store = loadStore();
+  const t = store.times[statsKey(type, difficulty)];
   return typeof t === 'number' ? t : null;
 }
 
 /**
- * Compares elapsedSeconds to the stored best for difficulty.
+ * Compares elapsedSeconds to the stored best for variant+difficulty.
  * If it's a new best (or first time), saves it and returns true.
  * Otherwise returns false.
  */
-export function updateBestTime(difficulty: DifficultyLevel, elapsedSeconds: number): boolean {
-  const times = loadBestTimes();
-  const current = times[difficulty];
+export function updateBestTime(
+  type: SudokuTypeId,
+  difficulty: DifficultyLevel,
+  elapsedSeconds: number,
+): boolean {
+  const store = loadStore();
+  const key = statsKey(type, difficulty);
+  const current = store.times[key];
   if (typeof current === 'number' && current <= elapsedSeconds) return false;
+  const next: StoreV2 = {
+    version: BEST_TIMES_VERSION,
+    times: { ...store.times, [key]: elapsedSeconds },
+  };
   try {
-    localStorage.setItem(BEST_TIMES_KEY, JSON.stringify({ ...times, [difficulty]: elapsedSeconds }));
+    localStorage.setItem(BEST_TIMES_KEY, JSON.stringify(next));
     return true;
   } catch {
     // Private browsing or quota: can't record the new best, so don't claim it.


### PR DESCRIPTION
## Summary
Closes #222. `bestTime` was keyed by difficulty alone (`{ EASY: 142, ... }`), so a fast Classic Easy hid (and was hidden by) a slower Killer Easy. Stats already keyed `${type}-${difficulty}`, so the two disagreed and the bestTime UI showed a dishonest claim for variant players.

- New v2 schema: `{ version: 2, times: { "CLASSIC-EASY": 142, "KILLER-EASY": 285, ... } }`.
- `getBestTime` / `updateBestTime` now take `(type, difficulty)`. The single existing caller in `GameContainer.tsx:156` already had `state.sudokuType` in scope.
- v1 → v2 auto-migration on first load: each v1 entry becomes `CLASSIC-{difficulty}` (Classic was the only variant most users completed before variant gameplay shipped). Other variants start fresh — intentional, not a regression. Migrated store is written back so subsequent reads skip the migration path.
- Future-version stores read as empty rather than corrupted (defense-in-depth for a hypothetical v3 writer).

## Test plan
- [x] `npx vitest run src/utils/bestTime.test.ts` — 15/15 pass (7 existing + 2 cross-variant + 5 migration + 1 future-version guard).
- [x] Full unit suite, typecheck, lint clean.
- [ ] Manual: solve Classic Easy, then Killer Easy. Confirm both display their own bestTime independently (was: only the fastest of the two showed for both).
- [ ] Manual: open the app with a v1 store seeded in localStorage (`{"EASY":120}`), confirm Classic Easy bestTime reads 120 and Killer Easy shows no bestTime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)