### PR TITLE
fix(generator): check uniqueness on every Classic removal (#214)

### DIFF
--- a/src/utils/sudokuGenerator.test.ts
+++ b/src/utils/sudokuGenerator.test.ts
@@ -5,9 +5,10 @@ import { solveSudoku, hasUniqueSolution } from './sudokuSolver';
 import { GRID_SIZE, EMPTY_CELL, KING_MOVES } from './constants';
 import type { Board } from '../types/index';
 
-// Suppress unused import warning - these are used in commented-out or conditional tests
+// solveSudoku is imported for use in commented-out/conditional tests
+// elsewhere in this file. hasUniqueSolution is now exercised by the
+// #214 regression tests below.
 void solveSudoku;
-void hasUniqueSolution;
 
 describe('Sudoku Generator', () => {
   describe('generateFullBoard', () => {
@@ -61,6 +62,36 @@ describe('Sudoku Generator', () => {
             expect(puzzle[row]![col]).toBe(solution[row]![col]);
           }
         }
+      }
+    });
+
+    // Regression #214 — the previous generator only checked
+    // hasUniqueSolution every 5th removal (and on the last 5). Between
+    // two checks, 1-4 unchecked removals could introduce a second
+    // solution; the next check then failed on an unrelated cell, the
+    // restore put back the wrong cell, and the puzzle shipped
+    // non-unique. With every-removal checking, this can no longer
+    // happen — the invariant "puzzle is unique after every accepted
+    // removal" holds at every step. We exercise EXPERT (~50 removals,
+    // most pressure on the solver) and a sample size of 5 generations
+    // because the bug was probabilistic; a single run could pass even
+    // against the buggy code.
+    //
+    // Per-test timeout bumped to 30s: EXPERT generation runs the
+    // solver on every accepted removal, so the worst-case cost
+    // (median ~275ms / max ~1.4s per generation locally) makes 5
+    // iterations occasionally bump up against vitest's 5s default.
+    it('should produce uniquely-solvable EXPERT puzzles every time', { timeout: 30_000 }, () => {
+      for (let i = 0; i < 5; i++) {
+        const { puzzle } = createPuzzle('EXPERT');
+        expect(hasUniqueSolution(puzzle, 'CLASSIC')).toBe(true);
+      }
+    });
+
+    it('should produce uniquely-solvable HARD puzzles every time', { timeout: 30_000 }, () => {
+      for (let i = 0; i < 5; i++) {
+        const { puzzle } = createPuzzle('HARD');
+        expect(hasUniqueSolution(puzzle, 'CLASSIC')).toBe(true);
       }
     });
   });

--- a/src/utils/sudokuGenerator.ts
+++ b/src/utils/sudokuGenerator.ts
@@ -686,12 +686,21 @@ function _createPuzzle(difficulty: DifficultyLevel, sudokuType: SudokuTypeId): P
       // For special sudoku types, just remove cells without checking uniqueness
       removed++;
     } else {
-      // Check if puzzle still has unique solution
-      // For performance, only check uniqueness every few removals
-      const shouldCheckUniqueness = removed % 5 === 0 || removed >= cellsToRemove - 5;
-
-      if (shouldCheckUniqueness && !hasUniqueSolution(puzzle, sudokuType)) {
-        // Restore the cell if solution is not unique
+      // Check uniqueness on EVERY removal (#214). The earlier "check
+      // every 5th + last 5" shortcut could ship non-unique Classic
+      // puzzles: between two checks 1-4 unchecked removals could
+      // introduce a second solution; the next check then failed on
+      // an unrelated cell while the actual culprits stayed empty,
+      // so the restore was on the wrong cell and the puzzle stayed
+      // non-unique. Keeping the invariant strict (puzzle is unique
+      // after every accepted removal) eliminates the class of bug
+      // entirely. hasUniqueSolution short-circuits at 2 solutions,
+      // so the cost on Expert is a few extra cell-attempts per
+      // generation — empirically still well under the unit-test
+      // timeout.
+      if (!hasUniqueSolution(puzzle, sudokuType)) {
+        // Restore the cell — this removal would have introduced a
+        // second solution.
         puzzle[row][col] = backup;
       } else {
         removed++;


### PR DESCRIPTION
## Summary
Closes #214. The Classic generator skipped uniqueness checks for 4 of every 5 removals. Between two checks, those unchecked removals could introduce a second solution; the next check then failed on an unrelated cell, the restore went to the wrong cell, and a non-unique puzzle shipped.

Dropped the every-5 shortcut. Invariant is now: puzzle is uniquely solvable after every accepted removal. Cost is a few extra solver calls per Expert generation (~50 cells × hasUniqueSolution), median ~275ms / max ~1.4s per generation locally.

## Test plan
- [x] `npx vitest run src/utils/sudokuGenerator.test.ts` — 27/27 pass; the two new regression cases assert `hasUniqueSolution` over 5 generations each at HARD and EXPERT.
- [x] Full unit suite, typecheck, lint clean.
- [x] Profiled generation locally: HARD median 41ms / max 179ms / sum 498ms over 10 runs; EXPERT median 275ms / max 1.4s / sum 3.83s over 10 runs.
- [ ] Manual: generate a few Classic Expert puzzles in the running app and confirm "Check Solution" accepts the player's solve every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)