### PR TITLE
fix(killer): wire difficulty into cage size distribution (#220)

### DIFF
--- a/src/utils/sudokuGenerator.test.ts
+++ b/src/utils/sudokuGenerator.test.ts
@@ -361,6 +361,94 @@ describe('Sudoku Generator', () => {
           expect(cage.sum).toBe(expected);
         }
       });
+
+      // Regression #220 — the Killer branch in _createPuzzle early-
+      // returned BEFORE reading DIFFICULTY_LEVELS, so every difficulty
+      // (Easy through Expert) produced the same 2-5-cell uniform cage
+      // distribution. The "Difficulty" UI selector was a placebo for
+      // Killer. The fix wires difficulty into generateKillerCages with
+      // distinct size ranges per level.
+      describe('difficulty controls cage size distribution (#220)', () => {
+        // Helper: average cage size over N generations with seeds 0..N-1.
+        // Sample size is large enough (30) to drown out single-seed
+        // outliers from leftover-pocket degeneracy.
+        function averageCageSize(difficulty: 'EASY' | 'MEDIUM' | 'HARD' | 'EXPERT'): number {
+          const SAMPLES = 30;
+          let totalCells = 0;
+          let totalCages = 0;
+          for (let seed = 0; seed < SAMPLES; seed++) {
+            const { killerCages } = createPuzzle(difficulty, 'KILLER', seed);
+            for (const cage of killerCages!) {
+              totalCells += cage.cells.length;
+              totalCages += 1;
+            }
+          }
+          return totalCells / totalCages;
+        }
+
+        it('average cage size grows with difficulty', () => {
+          const easy = averageCageSize('EASY');
+          const medium = averageCageSize('MEDIUM');
+          const hard = averageCageSize('HARD');
+          const expert = averageCageSize('EXPERT');
+          // Strict monotonicity is too brittle (medium and hard ranges
+          // overlap intentionally — 2-4 vs 3-5). Anchor the extremes
+          // and let the middle sit between.
+          expect(easy).toBeLessThan(medium);
+          expect(hard).toBeLessThan(expert);
+          expect(easy).toBeLessThan(expert);
+        });
+
+        it('EASY produces noticeably more 1-cell "naked single" cages than EXPERT', () => {
+          // EASY seeds 15% of cages as 1-cell hints on top of any
+          // pocket-degeneracy. EXPERT only gets the degeneracy floor
+          // (it never seeds 1-cell). Empirically across 30 seeds,
+          // EASY shows ~3-4× more singletons than EXPERT — the gap
+          // is what proves the deliberate hint-cage logic actually
+          // fires. Asserting the GAP rather than absolute thresholds
+          // keeps the test robust against future tweaks to the
+          // 15% rate.
+          let easySingles = 0;
+          let expertSingles = 0;
+          for (let seed = 0; seed < 30; seed++) {
+            const easy = createPuzzle('EASY', 'KILLER', seed);
+            const expert = createPuzzle('EXPERT', 'KILLER', seed);
+            for (const cage of easy.killerCages!) {
+              if (cage.cells.length === 1) easySingles += 1;
+            }
+            for (const cage of expert.killerCages!) {
+              if (cage.cells.length === 1) expertSingles += 1;
+            }
+          }
+          // 1.5× floor — well below the ~2.9× empirical ratio, well
+          // above the noise floor.
+          expect(easySingles).toBeGreaterThan(expertSingles * 1.5);
+        });
+
+        it('cage sizes never exceed the difficulty-allowed maximum', () => {
+          // Cages can degenerate BELOW the min (when growth gets
+          // stuck on assigned-or-duplicate-digit neighbours), but
+          // they cannot exceed the max — that would mean the
+          // targetSize logic regressed. Pin the upper bound and let
+          // degeneracy float on the lower side.
+          const checks: Array<[
+            'EASY' | 'MEDIUM' | 'HARD' | 'EXPERT', number
+          ]> = [
+            ['EASY', 3],
+            ['MEDIUM', 4],
+            ['HARD', 5],
+            ['EXPERT', 5],
+          ];
+          for (const [difficulty, hi] of checks) {
+            for (let seed = 0; seed < 5; seed++) {
+              const { killerCages } = createPuzzle(difficulty, 'KILLER', seed);
+              for (const cage of killerCages!) {
+                expect(cage.cells.length).toBeLessThanOrEqual(hi);
+              }
+            }
+          }
+        });
+      });
     });
   });
 });

--- a/src/utils/sudokuGenerator.ts
+++ b/src/utils/sudokuGenerator.ts
@@ -352,11 +352,42 @@ interface KillerCageInternal {
 }
 
 /**
+ * Cage-size distribution per difficulty (#220). The earlier generator
+ * sampled targetSize uniformly from 2-5 regardless of difficulty —
+ * combined with a callsite that early-returned BEFORE reading the
+ * difficulty config, every Killer puzzle was effectively the same
+ * class regardless of selector. Now:
+ *   - EASY: small cages (2-3) plus an occasional 1-cell "free digit"
+ *     cage so the player gets a hint sum to anchor their solve.
+ *   - MEDIUM: 2-4, the historical default range with the lower end
+ *     trimmed.
+ *   - HARD: skews larger (3-5) — fewer tight pairs to crack.
+ *   - EXPERT: 4-5 only — largest search space, no naked-single hints.
+ *
+ * EASY is the only difficulty where 1-cell cages can be SEEDED. A
+ * cage can still degenerate to size 1 at any difficulty if it gets
+ * stuck with no eligible orthogonal neighbours (assigned-or-duplicate-
+ * digit), but that's a leftover-pocket case, not a deliberate hint.
+ */
+function killerCageSizeRange(difficulty: DifficultyLevel): { min: number; max: number } {
+  switch (difficulty) {
+    case 'EASY':   return { min: 2, max: 3 };
+    case 'MEDIUM': return { min: 2, max: 4 };
+    case 'HARD':   return { min: 3, max: 5 };
+    case 'EXPERT': return { min: 4, max: 5 };
+  }
+}
+
+const KILLER_EASY_SINGLE_CAGE_RATE = 0.15;
+
+/**
  * Generate Killer Sudoku cages from a completed solution
  * @param solution - The solution board
+ * @param difficulty - Difficulty level (controls cage size distribution)
  * @returns Cages
  */
-function generateKillerCages(solution: Board): KillerCageInternal[] {
+function generateKillerCages(solution: Board, difficulty: DifficultyLevel): KillerCageInternal[] {
+  const { min: minSize, max: maxSize } = killerCageSizeRange(difficulty);
   const assigned: boolean[][] = Array(9).fill(null).map(() => Array(9).fill(false));
   const cages: KillerCageInternal[] = [];
   const allCells: { r: number; c: number }[] = [];
@@ -365,7 +396,12 @@ function generateKillerCages(solution: Board): KillerCageInternal[] {
 
   for (const { r, c } of cells) {
     if (assigned[r][c]) continue;
-    const targetSize = 2 + Math.floor(_rng() * 4); // 2-5
+    // EASY occasionally gets a 1-cell cage as a "free digit" hint.
+    // Other difficulties never SEED a singleton (they can still
+    // appear as the leftover-pocket degeneracy, see while-loop below).
+    const targetSize = difficulty === 'EASY' && _rng() < KILLER_EASY_SINGLE_CAGE_RATE
+      ? 1
+      : minSize + Math.floor(_rng() * (maxSize - minSize + 1));
     const cageCells: CellPosition[] = [{ row: r, col: c }];
     assigned[r][c] = true;
     // Track digits already inside this cage. Killer rules forbid the
@@ -636,9 +672,13 @@ export function createPuzzle(difficulty: DifficultyLevel = 'MEDIUM', sudokuType:
 function _createPuzzle(difficulty: DifficultyLevel, sudokuType: SudokuTypeId): PuzzleResult {
   const solution = generateFullBoard(sudokuType);
 
-  // Killer Sudoku: empty board + cages, no cell removal needed
+  // Killer Sudoku: empty board + cages, no cell removal needed.
+  // Difficulty controls cage-size distribution (#220) — see
+  // killerCageSizeRange. Before this fix, the early return ran before
+  // any difficulty config read, so every Killer puzzle had the same
+  // 2-5-cell uniform cage distribution regardless of selector.
   if (sudokuType === 'KILLER') {
-    const killerCages = generateKillerCages(solution);
+    const killerCages = generateKillerCages(solution, difficulty);
     return { puzzle: createEmptyBoard(), solution, oddEvenMarkers: null, kropkiDots: null, killerCages, littleKillerClues: null, greaterThanSigns: null, thermos: null, sandwichClues: null };
   }
 


### PR DESCRIPTION
## Summary
Closes #220. Killer's `_createPuzzle` branch early-returned before reading `DIFFICULTY_LEVELS`, so every difficulty produced the same uniform 2–5-cell cage distribution. The Difficulty UI selector was a placebo for Killer.

Wired difficulty into `generateKillerCages` with distinct size ranges:
- **EASY** — 2-3 cells, plus 15% chance of a 1-cell "naked single" hint cage.
- **MEDIUM** — 2-4 cells.
- **HARD** — 3-5 cells (skews larger).
- **EXPERT** — 4-5 cells only.

Empirical distribution over 30 seeds:

| difficulty | avg | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|---|
| EASY   | 1.98 | 397 | 460 | 371 |  -  |  -  |
| MEDIUM | 2.53 | 181 | 307 | 253 | 219 |  -  |
| HARD   | 3.21 | 143 |  54 | 212 | 197 | 151 |
| EXPERT | 3.52 | 137 |  51 |  40 | 244 | 219 |

The 1-cell counts at HARD/EXPERT are leftover-pocket degeneracy (cage growth gets stuck on assigned-or-duplicate-digit neighbours) — a structural property of the orthogonal-adjacency growth, not a difficulty regression. EASY still shows ~3× the 1-cell rate of EXPERT, proving the deliberate hint logic fires above the floor.

## Test plan
- [x] `npx vitest run src/utils/sudokuGenerator.test.ts` — 30/30 pass; full suite green; typecheck + lint clean.
- [x] Three new regression cases: average grows with difficulty, EASY has noticeably more 1-cell hint cages than EXPERT, cage sizes never exceed the difficulty-allowed maximum.
- [ ] Manual: open Killer at EASY and EXPERT with the same seed, confirm cage layouts differ visibly (was: identical).
- [ ] Manual: spot-check that EASY surfaces some 1-cell "free digit" cages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)