### PR TITLE
fix(generator): enforce uniqueness on every removal for all variants (#211)

### DIFF
--- a/src/utils/sudokuGenerator.test.ts
+++ b/src/utils/sudokuGenerator.test.ts
@@ -3,7 +3,7 @@ import { generateFullBoard, createPuzzle, getHint } from './sudokuGenerator';
 import { isSolved, isComplete, findConflicts } from './sudokuValidator';
 import { solveSudoku, hasUniqueSolution } from './sudokuSolver';
 import { GRID_SIZE, EMPTY_CELL, KING_MOVES } from './constants';
-import type { Board } from '../types/index';
+import type { Board, SudokuTypeId } from '../types/index';
 
 // solveSudoku is imported for use in commented-out/conditional tests
 // elsewhere in this file. hasUniqueSolution is now exercised by the
@@ -44,7 +44,7 @@ describe('Sudoku Generator', () => {
       expect(filledCells).toBeLessThanOrEqual(60);
     });
 
-    it('should create puzzle with correct difficulty (EXPERT)', () => {
+    it('should create puzzle with correct difficulty (EXPERT)', { timeout: 30_000 }, () => {
       const { puzzle } = createPuzzle('EXPERT');
       const filledCells = puzzle.flat().filter((cell) => cell !== EMPTY_CELL).length;
       // EXPERT: should have fewer filled cells (allow margin for uniqueness constraint)
@@ -81,17 +81,44 @@ describe('Sudoku Generator', () => {
     // solver on every accepted removal, so the worst-case cost
     // (median ~275ms / max ~1.4s per generation locally) makes 5
     // iterations occasionally bump up against vitest's 5s default.
-    it('should produce uniquely-solvable EXPERT puzzles every time', { timeout: 30_000 }, () => {
+    it('should produce uniquely-solvable EXPERT puzzles every time', { timeout: 60_000 }, () => {
       for (let i = 0; i < 5; i++) {
         const { puzzle } = createPuzzle('EXPERT');
         expect(hasUniqueSolution(puzzle, 'CLASSIC')).toBe(true);
       }
     });
 
-    it('should produce uniquely-solvable HARD puzzles every time', { timeout: 30_000 }, () => {
+    it('should produce uniquely-solvable HARD puzzles every time', { timeout: 60_000 }, () => {
       for (let i = 0; i < 5; i++) {
         const { puzzle } = createPuzzle('HARD');
         expect(hasUniqueSolution(puzzle, 'CLASSIC')).toBe(true);
+      }
+    });
+
+    // Regression #211 — non-Classic variants used to skip uniqueness
+    // checking entirely. Players solving via an alternate valid
+    // solution would see "Wrong" from the Check button, and the hint
+    // engine could push them toward the OTHER solution. Now uniqueness
+    // is enforced on every removal for all 11 non-Killer variants.
+    // KILLER uses a separate empty-board path and is excluded; the
+    // cage-validity invariant is covered elsewhere (#210).
+    //
+    // Per-test timeout 60s: all 11 variants × MEDIUM (one pass each)
+    // takes ~2s typical, well under budget. EXPERT cost would push
+    // ~10s — we use MEDIUM here for breadth; EXPERT is exercised by
+    // the Classic-only block above.
+    it('should produce uniquely-solvable puzzles for every non-Killer variant', { timeout: 60_000 }, () => {
+      const variants: SudokuTypeId[] = [
+        'DIAGONAL', 'WINDOKU', 'ANTI_KNIGHT', 'ODD_EVEN', 'ANTI_KING',
+        'NON_CONSECUTIVE', 'KROPKI', 'LITTLE_KILLER', 'GREATER_THAN',
+        'THERMO', 'SANDWICH',
+      ];
+      for (const v of variants) {
+        const { puzzle } = createPuzzle('MEDIUM', v);
+        expect(
+          hasUniqueSolution(puzzle, v),
+          `${v} puzzle should be structurally unique`,
+        ).toBe(true);
       }
     });
   });

--- a/src/utils/sudokuGenerator.ts
+++ b/src/utils/sudokuGenerator.ts
@@ -707,11 +707,35 @@ function _createPuzzle(difficulty: DifficultyLevel, sudokuType: SudokuTypeId): P
   let attempts = 0;
   const maxAttempts = GRID_SIZE * GRID_SIZE * 2;
 
-  // For special sudoku types, uniqueness checking is very slow, so we skip it
-  // and just remove the target number of cells
-  const skipUniquenessCheck = sudokuType !== 'CLASSIC';
-
-  // Remove cells while maintaining unique solution
+  // Remove cells while maintaining unique solution.
+  //
+  // Uniqueness is checked on EVERY removal for ALL variants. The
+  // earlier "every 5th" Classic shortcut (#214) could let unchecked
+  // removals introduce a second solution and then restore the wrong
+  // cell on the next check; the every-removal invariant — "puzzle is
+  // uniquely solvable after every accepted removal" — eliminates the
+  // class of bug. Variants used to skip the check entirely for perf,
+  // shipping multi-solution puzzles (#211) where the player could
+  // solve correctly via an alternate solution and the app marked it
+  // wrong. Empirical cost on EXPERT is <500ms typical / ~1s worst
+  // case across all 11 non-Killer variants — within an interactive
+  // generate-button budget. hasUniqueSolution short-circuits at 2
+  // solutions, so the worst-case work is bounded by the puzzle's
+  // first ambiguity.
+  //
+  // Caveat for data-driven variants (ODD_EVEN, KROPKI, GREATER_THAN,
+  // LITTLE_KILLER, THERMO, SANDWICH): variant CONSTRAINT DATA is
+  // generated below, AFTER this loop. The check here therefore
+  // enforces only the structural rules (rows/cols/boxes plus any
+  // sudokuType-encoded geometry like diagonals, windows, or anti-
+  // knight). Variant data only further restricts the solution space
+  // — it can never ADD solutions — so a structurally-unique puzzle
+  // here remains unique under full variant rules. The reverse case
+  // is conservative: a structurally-non-unique state might still be
+  // unique once data layers on, but we keep the rejected cell filled
+  // rather than chase that. The puzzle ends up slightly easier than
+  // the difficulty target, which is a much smaller harm than
+  // shipping non-unique solutions.
   for (const { row, col } of shuffledPositions) {
     if (removed >= cellsToRemove || attempts >= maxAttempts) {
       break;
@@ -722,29 +746,11 @@ function _createPuzzle(difficulty: DifficultyLevel, sudokuType: SudokuTypeId): P
     const backup = puzzle[row][col];
     puzzle[row][col] = EMPTY_CELL;
 
-    if (skipUniquenessCheck) {
-      // For special sudoku types, just remove cells without checking uniqueness
-      removed++;
+    if (!hasUniqueSolution(puzzle, sudokuType)) {
+      // Restore — this removal would have introduced a second solution.
+      puzzle[row][col] = backup;
     } else {
-      // Check uniqueness on EVERY removal (#214). The earlier "check
-      // every 5th + last 5" shortcut could ship non-unique Classic
-      // puzzles: between two checks 1-4 unchecked removals could
-      // introduce a second solution; the next check then failed on
-      // an unrelated cell while the actual culprits stayed empty,
-      // so the restore was on the wrong cell and the puzzle stayed
-      // non-unique. Keeping the invariant strict (puzzle is unique
-      // after every accepted removal) eliminates the class of bug
-      // entirely. hasUniqueSolution short-circuits at 2 solutions,
-      // so the cost on Expert is a few extra cell-attempts per
-      // generation — empirically still well under the unit-test
-      // timeout.
-      if (!hasUniqueSolution(puzzle, sudokuType)) {
-        // Restore the cell — this removal would have introduced a
-        // second solution.
-        puzzle[row][col] = backup;
-      } else {
-        removed++;
-      }
+      removed++;
     }
   }
 


### PR DESCRIPTION
## Summary
Closes #211. Non-Classic variants used to skip uniqueness checking entirely (`skipUniquenessCheck = sudokuType !== 'CLASSIC'`), shipping multi-solution puzzles where the player could solve correctly via an alternate valid solution and Check would mark them wrong. The hint engine also assumed uniqueness, which is why Unique Rectangle had to be gated on Classic in #213.

The every-removal uniqueness invariant from #214 now applies to ALL variants.

**Perf**: empirical cost on EXPERT is <500ms typical / ~1s worst case across all 11 non-Killer variants, with `hasUniqueSolution` short-circuiting at 2 solutions. Within an interactive generate-button budget.

**Caveat for data-driven variants** (ODD_EVEN, KROPKI, GREATER_THAN, LITTLE_KILLER, THERMO, SANDWICH): variant CONSTRAINT DATA is generated AFTER cell removal, so this check enforces structural rules only. Variant data only further restricts the solution space — it never adds solutions — so a structurally-unique puzzle here remains unique under full variant rules. The reverse case (structurally-non-unique → maybe unique with data) is handled conservatively: keep the cell filled. Net effect: slightly easier puzzles than difficulty target for those six variants. Much smaller harm than shipping non-unique.

**Test timeouts** bumped to 30s/60s on the EXPERT-related tests since the median ~275ms / max ~1.4s solver-call cost can spike past vitest's 5s default under parallel load.

## Test plan
- [x] `npx vitest run src/utils/sudokuGenerator.test.ts` — 31/31 pass; new regression covers all 11 non-Killer variants.
- [x] Full unit suite, typecheck, lint clean.
- [x] Profiled all variants at MEDIUM and EXPERT (<500ms typical, ~1s worst).
- [ ] Manual: solve a Killer-free variant (e.g. Diagonal, Windoku, Anti-Knight) and confirm Check accepts the solve and the hint engine doesn't push toward an alternate solution.

## Note
This closes the last issue from the original /codex challenge round and post-hoc /codex review of PR #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)