### PR TITLE
docs(readme): sync hint chain + difficulty copy with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ### Игровой движок
 - ✅ **13 вариантов** — Classic, Diagonal, Windoku, Killer, Thermo, Sandwich, Anti-Knight, Anti-King, Odd-Even, Kropki, Greater-Than, Non-Consecutive, Little-Killer
-- ✅ **4 уровня сложности** — от Легкого (40-50 заполненных ячеек, 5 подсказок) до Эксперта (20-25, 3 подсказки)
-- ✅ **Система подсказок** с pedagogically-graded техниками (Naked Single → X-Wing → XYZ-Wing) и читаемыми объяснениями
+- ✅ **4 уровня сложности** — от Легкого (40-50 заполненных ячеек) до Эксперта (20-25)
+- ✅ **Система подсказок** (10 на партию) с pedagogically-graded техниками и читаемыми объяснениями: Naked/Hidden Single, Locked Candidates, Naked/Hidden Pair/Triple/Quad, X-Wing/Swordfish/Jellyfish, XY-Wing, XYZ-Wing, W-Wing, Unique Rectangle (только Classic), Simple Coloring
 - ✅ **Режим заметок** для записи кандидатов
 - ✅ **Undo/Redo** через историю снимков
-- ✅ **Mistake limit** опциональный — после N ошибок игра завершается
+- ✅ **Mistake limit** опциональный (toggle) — лимит зависит от сложности (5/4/3/3), при достижении игра завершается
 
 ### Daily puzzle
 - ✅ **Ежедневная головоломка** — детерминированная по UTC date-based seed, одинаковая для всех игроков
@@ -153,7 +153,7 @@ src/
     ├── candidateGrid.ts
     ├── constants.ts              # GAME_STATUS, DIFFICULTY_LEVELS, SUDOKU_TYPES, STORAGE_KEY
     ├── dailyPuzzle.ts            # UTC dayNumber, store v1→v2 migration, future-date guard
-    ├── hintEngine.ts             # Solver chain: Naked Single → X-Wing → XYZ-Wing
+    ├── hintEngine.ts             # Solver chain: singles → locked candidates → naked/hidden subsets → fish (X-Wing/Swordfish/Jellyfish) → XY-/XYZ-/W-Wing → Unique Rectangle (Classic only) → Simple Coloring
     ├── seededRandom.ts
     ├── seoUrls.ts                # canonicalUrl, hreflangAlternates, OG_IMAGE_URL
     ├── share.ts                  # navigator.share / clipboard fallback


### PR DESCRIPTION
## Summary

Post-PR-#250 codebase audit turned up three places where the README had drifted from what the code actually does. README-only change, no behavioral impact.

- **Difficulty bullet** said _Easy 5 подсказок ... Expert 3 подсказки_. That's the per-difficulty `mistakeLimit` (5/4/3/3) misnamed as hints. `constants.ts` ships `maxHints: 10` for every difficulty; the only per-level knob is the optional `mistakeLimit` toggle.
- **Hint engine bullet** said the solver chain was _Naked Single → X-Wing → XYZ-Wing_. The actual `TECHNIQUES` array in `src/utils/hintEngine.ts` is much longer: singles, locked candidates, naked/hidden subsets through quad, X-Wing/Swordfish/Jellyfish, XY-/XYZ-/W-Wing, Unique Rectangle (gated to Classic per #213), Simple Coloring.
- **Architecture file-map entry** for `hintEngine.ts` updated to the same fuller chain.

Everything else in the README — 13 variants, 28 prerendered URLs, prerender pipeline, bestTime per variant×difficulty (#222), storage migrations, GameContainer hook split (#116), Tailwind 4, perf numbers — already matches HEAD.

## Test plan

- [ ] Render README on GitHub and confirm both bullets read cleanly
- [ ] Confirm the `hintEngine.ts` line in the file tree wraps acceptably in the rendered tree block

🤖 Generated with [Claude Code](https://claude.com/claude-code)