### PR TITLE
style(design): a11y + visibility quick wins (5 fixes)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       (PR3 of #23) and live JS pages alike.
     -->
     <meta name="theme-color" content="#7c3aed" />
+    <meta name="color-scheme" content="light dark" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/components/Board/Cell.tsx
+++ b/src/components/Board/Cell.tsx
@@ -196,7 +196,7 @@ export const Cell = memo(function Cell({
       {cageLeft   && <div className={`absolute top-0 left-0 bottom-0 w-0 pointer-events-none z-20 border-l-2 ${colorBlindMode ? 'border-dotted border-orange-500' : 'border-dashed border-violet-600'}`} />}
       {/* Killer Sudoku: cage sum in top-left corner */}
       {cageSum !== null && (
-        <span className={`absolute top-0.5 left-0.5 z-20 pointer-events-none font-bold leading-none select-none text-[9px] ${colorBlindMode ? 'text-orange-600 dark:text-orange-400' : 'text-violet-700 dark:text-violet-400'}`}>
+        <span className={`absolute top-0.5 left-0.5 z-20 pointer-events-none font-bold leading-none select-none text-xs ${colorBlindMode ? 'text-orange-600 dark:text-orange-400' : 'text-violet-700 dark:text-violet-400'}`}>
           {cageSum}
         </span>
       )}

--- a/src/components/Controls/DifficultySelector.tsx
+++ b/src/components/Controls/DifficultySelector.tsx
@@ -24,7 +24,7 @@ export function DifficultySelector({ currentDifficulty, onDifficultyChange, disa
           disabled={disabled}
           role="radio"
           aria-checked={currentDifficulty === level}
-          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+          className={`px-4 py-2 min-h-[44px] rounded-lg font-medium transition-colors ${
             currentDifficulty === level
               ? 'bg-blue-600 text-white'
               : 'bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600'

--- a/src/components/Game/GameContainer.tsx
+++ b/src/components/Game/GameContainer.tsx
@@ -299,9 +299,9 @@ export function GameContainer({ forcedVariant, headingTitle, landingContent }: G
 
   return (
     <div className="min-h-screen bg-gray-100 dark:bg-gray-900 py-4 px-2 sm:py-8 sm:px-4">
-      <div className="max-w-6xl mx-auto">
+      <main className="max-w-6xl mx-auto">
         {/* Header with title and language switcher */}
-        <div className="flex items-center justify-between mb-4 sm:mb-8 print:hidden">
+        <header className="flex items-center justify-between mb-4 sm:mb-8 print:hidden">
           {/*
             Wordmark with a small 3x3 grid mark (#130). The mark gives the
             "Sudoku" text some brand specificity — without it the wordmark
@@ -366,7 +366,7 @@ export function GameContainer({ forcedVariant, headingTitle, landingContent }: G
               onPrint={() => window.print()}
             />
           </div>
-        </div>
+        </header>
 
         {/* Daily streak — full-width hero above the board */}
         <StreakBanner
@@ -469,7 +469,7 @@ export function GameContainer({ forcedVariant, headingTitle, landingContent }: G
           </div>
 
           {/* Right side - Controls */}
-          <div className="flex flex-col gap-4 md:gap-6 w-full md:w-auto md:min-w-[280px] print:hidden">
+          <aside aria-label={t('game.controlsLandmarkLabel', 'Game controls')} className="flex flex-col gap-4 md:gap-6 w-full md:w-auto md:min-w-[280px] print:hidden">
             {/* Number Pad — topmost so it's adjacent to the board */}
             <div data-tour="numberpad" className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 sm:p-6">
               <h2 className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-3 text-center">
@@ -609,9 +609,9 @@ export function GameContainer({ forcedVariant, headingTitle, landingContent }: G
             {/* Onboarding tour */}
             {tourOpen && <OnboardingTour onClose={closeTour} />}
 
-          </div>
+          </aside>
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "time": "Time:",
     "type": "Type:",
     "difficulty": "Difficulty:",
+    "controlsLandmarkLabel": "Game controls",
     "numberInput": "Number Input:",
     "selectCellHint": "Select a cell to enter a number",
     "paused": "Game Paused",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -17,6 +17,7 @@
     "time": "Время:",
     "type": "Тип:",
     "difficulty": "Сложность:",
+    "controlsLandmarkLabel": "Управление игрой",
     "numberInput": "Ввод чисел:",
     "selectCellHint": "Выберите ячейку для ввода числа",
     "paused": "Игра на паузе",

--- a/src/index.css
+++ b/src/index.css
@@ -50,6 +50,16 @@
     outline: 2px solid theme('colors.blue.500');
     outline-offset: 2px;
   }
+
+  /* F8 — color-scheme tells the browser to render native UI (scrollbars,
+     autofill, <details> summary, form controls) in the matching variant.
+     Without this, scrollbars stay light inside a dark page. */
+  :root {
+    color-scheme: light;
+  }
+  :root.dark {
+    color-scheme: dark;
+  }
 }
 
 @layer utilities {

--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,15 @@
   body {
     @apply bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
   }
+
+  /* F7 — Global focus-visible fallback. WCAG 2.4.7. The :where() wrapper
+     makes this zero-specificity, so any component-level focus-visible:ring-*
+     utility wins. Catches bare <button>/<a> elements that don't ship their
+     own focus state (settings drawer items, tour nav, modal close buttons). */
+  :where(:focus-visible) {
+    outline: 2px solid theme('colors.blue.500');
+    outline-offset: 2px;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary

Five atomic, low-risk design fixes from `/design-review`. All changes are CSS or single-className edits; no logic changes.

| # | Fix | Files | Why |
|---|---|---|---|
| F1 | Semantic landmarks (`<main>`, `<header>`, `<aside>`) | `GameContainer.tsx` | Screen-reader users get skip-to-content; SEO can distinguish chrome from game. WCAG 1.3.1. |
| F2 | Killer cage sum 9px → 12px | `Cell.tsx` | Load-bearing data was below caption-readable size. Cross-model agreement (visual + Claude subagent). |
| F7 | Global `:focus-visible` fallback | `index.css` | 20 raw `<button>` elements across 11 files lacked focus indicators. WCAG 2.4.7. Zero-specificity `:where()` so component-level rings still win. |
| F8 | `color-scheme: light dark` on `:root` + meta tag | `index.css`, `index.html` | Native UI (scrollbars, autofill, `<details>`) was rendering light inside the dark page. |
| F9 | Difficulty buttons 40px → 44px min height | `DifficultySelector.tsx` | Touch target was below WCAG 2.5.5. Other surfaces (cells 50, NumberPad 48, ?-button 44 hit area) already conformed. |

## Verification

- `npx tsc --noEmit` clean
- `/design-review` baseline updated: Design score B → B+, AI Slop A−, goodwill 80/100
- `/qa` follow-up: health 94/100, 0 console errors across 13 game flows (home, daily, killer, x-sudoku, anti-knight, EN/RU, light/dark, mobile/tablet/desktop)
- All 5 fixes verified live via DOM inspection (landmark count went from 0 → 3, color-scheme toggles light↔dark with `.dark` class, cage sums readable on mobile, etc.)

## Deferred (future PRs)

- F3 unify primary action color (blue/indigo/purple) — needs Tailwind config + multi-component edit
- F5 brand mismatch ("Sudoku Sensei" in `<title>` vs "Sudoku" in H1) — needs design call
- F6 `role="grid"` + cell `role="button"` mismatch — keyboard handling rewrite in `Board.tsx`
- F10 stale daily-puzzle banner state
- F11 hardcoded board pixel constants (536/506/466/450/50/35/40 in `Board.tsx`) → CSS vars
- F12 emoji icons in settings drawer → icon library

## Test plan

- [ ] CI passes (typecheck, lint, vitest, e2e)
- [ ] Visual sanity: home page in light + dark mode, Killer variant board has readable cage sums
- [ ] Tab through the page — focus rings visible on every interactive element including settings drawer items
- [ ] Toggle dark mode — scrollbar/native UI flips to dark variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)